### PR TITLE
Seller console IA and management flow overhaul

### DIFF
--- a/src/common/api/queryRetry.js
+++ b/src/common/api/queryRetry.js
@@ -1,0 +1,9 @@
+export function shouldRetryRequest(failureCount, error) {
+  const status = error?.status
+
+  if (typeof status === "number" && status >= 400 && status < 500) {
+    return false
+  }
+
+  return failureCount < 2
+}

--- a/src/common/api/responseUtils.js
+++ b/src/common/api/responseUtils.js
@@ -1,0 +1,56 @@
+function createNormalizedApiError({
+  message,
+  status = null,
+  code = null,
+  method = null,
+  url = null,
+  body = null,
+}) {
+  const normalizedError = new Error(message)
+  normalizedError.status = status
+  normalizedError.code = code
+  normalizedError.method = method
+  normalizedError.url = url
+  normalizedError.body = body
+
+  return normalizedError
+}
+
+export function unwrapApiResponseBody(response, fallbackMessage = "데이터를 불러오지 못했습니다.") {
+  const body = response?.data
+
+  if (body?.success === true) {
+    return body.data
+  }
+
+  if (body?.success === false) {
+    const message = body?.error?.message || body?.message || fallbackMessage
+    throw createNormalizedApiError({
+      message,
+      status: response?.status ?? null,
+      code: body?.error?.code ?? null,
+      method: response?.config?.method?.toUpperCase?.() ?? null,
+      url: response?.config?.url ?? null,
+      body,
+    })
+  }
+
+  return body
+}
+
+export function normalizeApiError(error, fallbackMessage) {
+  const message =
+    error?.response?.data?.error?.message ||
+    error?.response?.data?.message ||
+    error?.message ||
+    fallbackMessage
+
+  return createNormalizedApiError({
+    message,
+    status: error?.response?.status ?? null,
+    code: error?.response?.data?.error?.code || error?.code || null,
+    method: error?.config?.method?.toUpperCase?.() ?? null,
+    url: error?.config?.url ?? null,
+    body: error?.response?.data ?? null,
+  })
+}

--- a/src/common/utils/id.js
+++ b/src/common/utils/id.js
@@ -1,0 +1,16 @@
+export function toIdString(value, fallback = "") {
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  const normalized = String(value).trim()
+  return normalized || fallback
+}
+
+export function encodeIdPathSegment(value, fallback = "") {
+  return encodeURIComponent(toIdString(value, fallback))
+}
+
+export function isNumericId(value) {
+  return /^\d+$/.test(toIdString(value))
+}

--- a/src/components/layout/BusinessLayout.jsx
+++ b/src/components/layout/BusinessLayout.jsx
@@ -1,107 +1,396 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router";
 import {
-  Store, Package, Zap, Tag, BarChart3, Globe,
-  LogOut, ChevronLeft, Menu, Sun, Moon,
+  LayoutDashboard,
+  Store,
+  Package,
+  Zap,
+  Tag,
+  Star,
+  MessageSquareMore,
+  Globe,
+  LogOut,
+  ChevronLeft,
+  Menu,
+  Sun,
+  Moon,
+  Sparkles,
+  ShieldCheck,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
-  { icon: Store,     label: "가게 생성",  path: "/business/store" },
-  { icon: Package,   label: "아이템 등록", path: "/business/items" },
-  { icon: Zap,       label: "펀딩 설정",  path: "/business/funding" },
-  { icon: Tag,       label: "핫딜 설정",  path: "/business/hotdeal" },
-  { icon: BarChart3, label: "판매 분석",  path: "/business/analytics" },
-  { icon: Globe,     label: "게이트웨이", path: "/business/gateway" },
+  {
+    icon: LayoutDashboard,
+    label: "대시보드",
+    path: "/business/dashboard",
+    kicker: "Sales Dashboard",
+    description: "매출과 주문 흐름, 주요 지표를 먼저 확인하는 메인 운영 화면입니다.",
+    focus: "오늘의 판매 흐름 확인",
+  },
+  {
+    icon: Store,
+    label: "가게 관리",
+    path: "/business/store",
+    kicker: "Store Management",
+    description: "가게 기본 정보와 운영 상태를 확인하고 관리하는 스토어 중심 화면입니다.",
+    focus: "스토어 정보 점검",
+  },
+  {
+    icon: Package,
+    label: "상품 관리",
+    path: "/business/items",
+    kicker: "Catalog Management",
+    description: "굿즈와 공연 상품을 같은 인터페이스 안에서 추가하고 정리합니다.",
+    focus: "상품 포트폴리오 운영",
+  },
+  {
+    icon: Zap,
+    label: "펀딩 관리",
+    path: "/business/funding",
+    kicker: "Funding Management",
+    description: "런칭 타이밍과 목표치를 설계해 전환을 끌어올리는 펀딩 플로우입니다.",
+    focus: "펀딩 캠페인 운영",
+  },
+  {
+    icon: Tag,
+    label: "핫딜 관리",
+    path: "/business/hotdeal",
+    kicker: "Hot Deal Management",
+    description: "할인 폭과 한정 수량을 조정해 급격한 수요를 만드는 세일 캡슐입니다.",
+    focus: "즉시성 있는 프로모션",
+  },
+  {
+    icon: Star,
+    label: "리뷰 관리",
+    path: "/business/reviews",
+    kicker: "Review Management",
+    description: "내 상품에 달린 리뷰를 상품 기준으로 모아보고 평점 흐름을 확인합니다.",
+    focus: "고객 피드백 확인",
+  },
+  {
+    icon: MessageSquareMore,
+    label: "채팅 문의",
+    path: "/business/messages",
+    kicker: "Chat Inbox",
+    description: "고객 문의 채팅방을 한곳에서 보고 답장하는 seller 문의함입니다.",
+    focus: "문의 응답 처리",
+  },
+  {
+    icon: Globe,
+    label: "연동 설정",
+    path: "/business/gateway",
+    kicker: "Integration Settings",
+    description: "API 키, 웹훅, 서비스 상태를 운영자 관점으로 안전하게 관리합니다.",
+    focus: "연동 안정성 유지",
+  },
 ];
 
 export default function BusinessLayout({ children }) {
   const location = useLocation();
+  const isAuthRoute = location.pathname.startsWith("/auth");
   const [collapsed, setCollapsed] = useState(false);
-  const [dark, setDark] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [dark, setDark] = useState(
+    () =>
+      typeof document !== "undefined" &&
+      document.documentElement.classList.contains("dark")
+  );
 
-  const toggleDark = () => {
-    setDark((d) => {
-      document.documentElement.classList.toggle("dark", !d);
-      return !d;
-    });
-  };
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+  }, [dark]);
 
-  return (
-    <div className="flex min-h-screen bg-background">
-      <aside
-        className="flex flex-col bg-sidebar border-r border-sidebar-border transition-all duration-300 shrink-0"
-        style={{ width: collapsed ? 64 : 240 }}
-      >
-        {/* Logo */}
-        <div className="flex items-center justify-between h-16 px-3 border-b border-sidebar-border">
-          {!collapsed && (
-            <span className="font-bold text-foreground text-sm tracking-tight pl-1 truncate">
-              Business
-            </span>
-          )}
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setCollapsed(!collapsed)}
-            className="h-8 w-8 shrink-0 text-muted-foreground"
+  const activeItem =
+    NAV_ITEMS.find((item) => item.path === location.pathname) ?? NAV_ITEMS[0];
+  const todayLabel = new Intl.DateTimeFormat("ko-KR", {
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+  }).format(new Date());
+
+  const renderNavigation = ({ compact = false, onSelect } = {}) => (
+    <nav className="flex flex-1 flex-col gap-2 overflow-y-auto">
+      {NAV_ITEMS.map(({ icon, label, path }) => {
+        const Icon = icon;
+        const active = location.pathname === path;
+        return (
+          <Link
+            key={path}
+            to={path}
+            onClick={onSelect}
+            title={compact ? label : undefined}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "group flex items-center gap-3 rounded-[1.35rem] px-3 py-3 text-sm font-medium transition-all duration-200",
+              compact ? "justify-center px-0" : "justify-between",
+              active
+                ? "bg-primary text-white shadow-[0_14px_30px_rgba(29,161,242,0.18)]"
+                : "text-sidebar-foreground hover:bg-white/64 hover:text-foreground dark:hover:bg-slate-900/54"
+            )}
           >
-            {collapsed ? <Menu size={16} /> : <ChevronLeft size={16} />}
-          </Button>
-        </div>
-
-        {/* Nav */}
-        <nav className="flex-1 py-3 px-2 flex flex-col gap-0.5 overflow-y-auto">
-          {NAV_ITEMS.map(({ icon: Icon, label, path }) => {
-            const active = location.pathname === path;
-            return (
-              <Link
-                key={path}
-                to={path}
-                title={collapsed ? label : undefined}
+            <span className="flex items-center gap-3">
+              <span
                 className={cn(
-                  "flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-150 text-sm font-medium",
+                  "grid h-10 w-10 place-items-center rounded-2xl border transition-colors",
                   active
-                    ? "bg-accent text-accent-foreground"
-                    : "text-sidebar-foreground hover:bg-accent/60 hover:text-accent-foreground"
+                    ? "border-white/12 bg-white/10 text-white"
+                    : "border-border bg-white/78 text-primary dark:border-slate-700 dark:bg-slate-950/40"
                 )}
               >
-                <Icon size={17} className="shrink-0" />
-                {!collapsed && <span className="truncate">{label}</span>}
-              </Link>
-            );
-          })}
-        </nav>
+                <Icon size={18} className="shrink-0" />
+              </span>
+              {!compact && <span className="truncate">{label}</span>}
+            </span>
+            {!compact && (
+              <span
+                className={cn(
+                  "h-2.5 w-2.5 rounded-full transition-all",
+                  active ? "bg-white/80" : "bg-slate-300 dark:bg-slate-700"
+                )}
+              />
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
 
-        <Separator />
+  if (isAuthRoute) {
+    return (
+      <div className="auth-stage min-h-screen px-4 py-4 sm:px-6 lg:px-8">
+        <div className="relative mx-auto grid min-h-[calc(100vh-2rem)] max-w-[1280px] gap-6 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+          <section className="glass-panel surface-hero hidden flex-col justify-between rounded-[2.25rem] px-8 py-8 lg:flex">
+            <div>
+              <Badge className="w-fit gap-1.5 rounded-full px-3 py-1 text-[0.72rem]">
+                <Sparkles size={12} />
+                돈모아
+              </Badge>
+              <h1 className="display-title mt-6 text-[clamp(2.8rem,4vw,4.6rem)] leading-[0.92] text-foreground">
+                판매 운영을
+                <br />
+                더 선명하게.
+              </h1>
+              <p className="mt-5 max-w-lg text-base leading-7 text-muted-foreground">
+                상품, 펀딩, 핫딜, 연동 설정까지 한 곳에서 관리하는 운영 콘솔입니다.
+                복잡한 입력 플로우를 더 가볍고 현대적인 시각 언어로 정리했습니다.
+              </p>
+            </div>
 
-        {/* Footer */}
-        <div className="p-2 flex flex-col gap-0.5">
-          <button
-            onClick={toggleDark}
-            title={collapsed ? (dark ? "라이트 모드" : "다크 모드") : undefined}
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg w-full text-sm text-muted-foreground hover:bg-accent/60 hover:text-foreground transition-colors"
-          >
-            {dark ? <Sun size={17} className="shrink-0" /> : <Moon size={17} className="shrink-0" />}
-            {!collapsed && <span>{dark ? "라이트 모드" : "다크 모드"}</span>}
-          </button>
-          <button
-            title={collapsed ? "로그아웃" : undefined}
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg w-full text-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
-          >
-            <LogOut size={17} className="shrink-0" />
-            {!collapsed && <span>로그아웃</span>}
-          </button>
+            <div className="grid gap-4">
+              {[
+                ["Flow", "멀티 스텝 폼과 운영 화면을 같은 톤으로 통합했습니다."],
+                ["Signal", "강한 타이포와 유리질 표면으로 정보 계층을 분명하게 만듭니다."],
+                ["Control", "데이터 바인딩은 유지한 채, 운영자가 다루는 감각만 재설계합니다."],
+              ].map(([label, text]) => (
+                <div
+                  key={label}
+                  className="metric-chip rounded-[1.75rem] px-5 py-4"
+                >
+                  <p className="section-kicker">{label}</p>
+                  <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                    {text}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <div className="flex items-center justify-center py-8 lg:py-10">
+            <div className="w-full max-w-[34rem]">{children}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="business-shell min-h-screen">
+      <div className="pointer-events-none absolute left-[-10rem] top-[-9rem] h-72 w-72 rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.18),transparent_66%)] blur-3xl" />
+      <div className="pointer-events-none absolute right-[-8rem] top-28 h-80 w-80 rounded-full bg-[radial-gradient(circle,rgba(14,165,233,0.12),transparent_70%)] blur-3xl" />
+
+      <aside
+        className="fixed inset-y-4 left-4 z-40 hidden shrink-0 xl:flex"
+        style={{ width: collapsed ? 110 : 286 }}
+      >
+        <div
+          className="glass-panel flex h-full w-full flex-col overflow-hidden rounded-[2.25rem] px-4 py-4"
+          style={{ width: collapsed ? 110 : 286 }}
+        >
+          <div className="flex items-center justify-between gap-3 pb-4">
+            <Link
+              to="/business/store"
+              className={cn("flex items-center gap-3", collapsed && "justify-center")}
+            >
+              <span className="grid h-12 w-12 place-items-center rounded-[1.4rem] bg-[linear-gradient(135deg,#38bdf8_0%,#1d9bf0_100%)] text-white shadow-[0_14px_30px_rgba(29,161,242,0.18)]">
+                <Sparkles size={20} />
+              </span>
+              {!collapsed && (
+                <span className="min-w-0">
+                  <span className="block truncate text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">
+                    Don-Moa
+                  </span>
+                  <span className="display-title block truncate text-xl font-semibold text-foreground">
+                    돈모아
+                  </span>
+                </span>
+              )}
+            </Link>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setCollapsed((value) => !value)}
+              className="shrink-0"
+              aria-label={collapsed ? "사이드바 확장" : "사이드바 축소"}
+            >
+              {collapsed ? <Menu size={16} /> : <ChevronLeft size={16} />}
+            </Button>
+          </div>
+
+          {!collapsed && (
+            <div className="metric-chip mb-4 rounded-[1.75rem] px-4 py-4">
+              <p className="section-kicker">Control Room</p>
+              <p className="mt-3 text-sm font-medium text-foreground">
+                판매 운영 흐름을 하나의 시각 언어로 통합했습니다.
+              </p>
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                현재 포커스: {activeItem.focus}
+              </p>
+            </div>
+          )}
+
+          {renderNavigation({ compact: collapsed })}
+
+          <Separator className="my-4 bg-white/70 dark:bg-slate-800" />
+
+          <div className="flex flex-col gap-2">
+            <button
+              type="button"
+              onClick={() => setDark((value) => !value)}
+              title={collapsed ? (dark ? "라이트 모드" : "다크 모드") : undefined}
+              className="flex items-center gap-3 rounded-[1.35rem] px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-white/66 hover:text-foreground dark:hover:bg-slate-900/54"
+            >
+              <span className="grid h-10 w-10 place-items-center rounded-2xl border border-white/70 bg-white/72 text-primary dark:border-slate-700 dark:bg-slate-950/40">
+                {dark ? <Sun size={17} /> : <Moon size={17} />}
+              </span>
+              {!collapsed && <span>{dark ? "라이트 모드" : "다크 모드"}</span>}
+            </button>
+            <button
+              type="button"
+              title={collapsed ? "로그아웃" : undefined}
+              className="flex items-center gap-3 rounded-[1.35rem] px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-rose-50 hover:text-rose-600 dark:hover:bg-rose-950/30 dark:hover:text-rose-300"
+            >
+              <span className="grid h-10 w-10 place-items-center rounded-2xl border border-white/70 bg-white/72 text-rose-500 dark:border-slate-700 dark:bg-slate-950/40">
+                <LogOut size={17} />
+              </span>
+              {!collapsed && <span>로그아웃</span>}
+            </button>
+          </div>
         </div>
       </aside>
 
-      <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
-        <div className="flex-1 overflow-y-auto p-6 sm:p-8">
-          {children}
+      <div
+        className={cn(
+          "relative mx-auto flex min-h-screen w-full max-w-[1550px] flex-1 flex-col px-4 py-4 sm:px-6 lg:px-8",
+          collapsed ? "xl:pl-[9rem]" : "xl:pl-[20rem]"
+        )}
+      >
+        <header className="sticky top-3 z-30 mb-5">
+          <div className="glass-panel overflow-hidden rounded-[1.7rem] px-4 py-3 sm:px-5">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline">{activeItem.kicker}</Badge>
+                  <Badge variant="outline">{todayLabel}</Badge>
+                </div>
+                <div className="mt-2 flex items-center gap-3">
+                  <h1 className="display-title truncate text-[clamp(1.2rem,1.3vw+0.9rem,1.85rem)] font-semibold leading-none text-foreground">
+                    {activeItem.label}
+                  </h1>
+                  <span className="hidden h-1.5 w-1.5 rounded-full bg-primary/70 sm:block" />
+                  <p className="hidden truncate text-sm text-muted-foreground xl:block">
+                    {activeItem.focus}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline" className="hidden md:inline-flex">
+                  {collapsed ? "Compact rail" : "Expanded rail"}
+                </Badge>
+                <Badge variant="outline" className="hidden xl:inline-flex">
+                  Seller workflow
+                </Badge>
+              </div>
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setDark((value) => !value)}
+              >
+                {dark ? <Sun size={14} /> : <Moon size={14} />}
+                {dark ? "라이트 모드" : "다크 모드"}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="xl:hidden"
+                onClick={() => setMobileOpen((value) => !value)}
+              >
+                <Menu size={14} />
+                메뉴
+              </Button>
+              <Badge className="gap-1.5 rounded-full px-3 py-1 text-[0.72rem]">
+                <ShieldCheck size={12} />
+                돈모아 콘솔
+              </Badge>
+            </div>
+          </div>
+        </header>
+
+        <main className="relative flex-1 pb-8">{children}</main>
+      </div>
+
+      <div
+        className={cn(
+          "fixed inset-0 z-50 xl:hidden",
+          mobileOpen ? "pointer-events-auto" : "pointer-events-none"
+        )}
+      >
+        <div
+          className={cn(
+            "absolute inset-0 bg-slate-950/28 backdrop-blur-sm transition-opacity",
+            mobileOpen ? "opacity-100" : "opacity-0"
+          )}
+          onClick={() => setMobileOpen(false)}
+        />
+        <div
+          className={cn(
+            "glass-panel absolute inset-y-4 left-4 flex w-[min(82vw,22rem)] flex-col rounded-[2rem] px-4 py-4 transition-transform duration-300",
+            mobileOpen ? "translate-x-0" : "-translate-x-[115%]"
+          )}
+        >
+          <div className="mb-4 flex items-center justify-between">
+            <div>
+              <p className="section-kicker">Navigate</p>
+              <p className="display-title mt-2 text-xl text-foreground">돈모아</p>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setMobileOpen(false)}
+            >
+              <ChevronLeft size={16} />
+            </Button>
+          </div>
+          {renderNavigation({ onSelect: () => setMobileOpen(false) })}
         </div>
-      </main>
+      </div>
     </div>
   );
 }

--- a/src/components/layout/PageIntro.jsx
+++ b/src/components/layout/PageIntro.jsx
@@ -1,0 +1,51 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export default function PageIntro({
+  eyebrow,
+  title,
+  description,
+  meta = [],
+  className,
+  children,
+}) {
+  return (
+    <section
+      className={cn(
+        "glass-panel surface-hero reveal-up relative overflow-hidden rounded-[2rem] px-5 py-5 sm:px-6 sm:py-6",
+        className
+      )}
+    >
+      <div className="pointer-events-none absolute right-[-4rem] top-[-4rem] h-36 w-36 rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.18),transparent_65%)]" />
+      <div className="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div className="max-w-3xl">
+          {eyebrow ? <p className="section-kicker">{eyebrow}</p> : null}
+          <h1 className="display-title mt-3 text-[clamp(2rem,2.1vw+1rem,3rem)] leading-[0.95] text-foreground">
+            {title}
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+            {description}
+          </p>
+          {meta.length > 0 ? (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {meta.map((item) => (
+                <Badge
+                  key={item}
+                  variant="outline"
+                  className="bg-white/72 text-[0.74rem] text-slate-600 dark:bg-slate-950/40 dark:text-slate-300"
+                >
+                  {item}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        {children ? (
+          <div className="flex w-full max-w-sm flex-col gap-3 lg:w-[21rem]">
+            {children}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -4,13 +4,13 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  "glass-panel group/alert relative grid w-full gap-0.5 rounded-[1.5rem] border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-card text-card-foreground",
+        default: "text-card-foreground",
         destructive:
-          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+          "border-rose-200/80 bg-rose-50/72 text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current dark:border-rose-900/70 dark:bg-rose-950/22",
       },
     },
     defaultVariants: {
@@ -39,7 +39,7 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="alert-title"
       className={cn(
-        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        "font-semibold group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
         className
       )}
       {...props}
@@ -55,7 +55,7 @@ function AlertDescription({
     <div
       data-slot="alert-description"
       className={cn(
-        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        "text-sm text-balance leading-6 text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
         className
       )}
       {...props}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,19 +5,20 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge inline-flex h-7 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-3 py-1 text-[0.74rem] font-semibold whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[4px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default:
+          "bg-primary text-primary-foreground shadow-[0_10px_22px_rgba(29,161,242,0.18)]",
         secondary:
-          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground dark:bg-slate-100 dark:text-slate-950",
         destructive:
-          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+          "bg-rose-500/12 text-rose-600 focus-visible:ring-destructive/20 dark:bg-rose-500/18 dark:text-rose-300 dark:focus-visible:ring-destructive/40",
         outline:
-          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+          "border-border bg-white/72 text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] dark:border-slate-700 dark:bg-slate-950/44",
         ghost:
-          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+          "hover:bg-white/70 hover:text-foreground dark:hover:bg-slate-900/52",
         link: "text-primary underline-offset-4 hover:underline",
       },
     },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,33 +5,33 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-clip-padding text-sm font-semibold whitespace-nowrap transition-all duration-200 outline-none select-none focus-visible:border-ring focus-visible:ring-4 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-4 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default:
+          "bg-[linear-gradient(135deg,#38bdf8_0%,#1d9bf0_100%)] text-white shadow-[0_14px_30px_rgba(29,161,242,0.2)] hover:brightness-[0.98]",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border-border bg-white/88 text-foreground shadow-[0_10px_24px_rgba(148,163,184,0.12)] hover:bg-accent aria-expanded:bg-accent dark:border-slate-700 dark:bg-slate-950/48 dark:hover:bg-slate-950/64",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "bg-secondary text-secondary-foreground shadow-[0_12px_26px_rgba(15,20,25,0.14)] hover:opacity-92 aria-expanded:opacity-92 dark:bg-slate-100 dark:text-slate-950 dark:hover:bg-white",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "text-muted-foreground hover:bg-accent hover:text-accent-foreground aria-expanded:bg-accent dark:hover:bg-slate-900/52",
         destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+          "bg-rose-500/12 text-rose-600 hover:bg-rose-500/18 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-rose-500/18 dark:text-rose-300 dark:hover:bg-rose-500/24 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
-        icon: "size-8",
+          "h-11 gap-2 px-5 has-data-[icon=inline-end]:pr-4 has-data-[icon=inline-start]:pl-4",
+        xs: "h-8 gap-1 rounded-full px-3 text-xs has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-9 gap-1.5 rounded-full px-4 text-[0.84rem] has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-12 gap-2 px-6 text-[0.95rem] has-data-[icon=inline-end]:pr-5 has-data-[icon=inline-start]:pl-5",
+        icon: "size-11",
         "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
+          "size-8 rounded-full [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-9 rounded-full",
+        "icon-lg": "size-12 rounded-full",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "glass-panel group/card flex flex-col gap-4 overflow-hidden rounded-[1.9rem] py-4 text-sm text-card-foreground has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-[1.9rem] *:[img:last-child]:rounded-b-[1.9rem]",
         className
       )}
       {...props}
@@ -25,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-[1.9rem] px-5 group-data-[size=sm]/card:px-4 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
         className
       )}
       {...props}
@@ -38,7 +38,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-title"
       className={cn(
-        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        "display-title text-lg leading-snug font-semibold group-data-[size=sm]/card:text-base",
         className
       )}
       {...props}
@@ -50,7 +50,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn("text-sm leading-6 text-muted-foreground", className)}
       {...props}
     />
   )
@@ -73,7 +73,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      className={cn("px-5 group-data-[size=sm]/card:px-4", className)}
       {...props}
     />
   )
@@ -84,7 +84,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        "flex items-center rounded-b-[1.9rem] border-t border-white/70 bg-white/45 p-5 group-data-[size=sm]/card:p-4 dark:border-slate-800 dark:bg-slate-950/24",
         className
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "glass-field h-11 w-full min-w-0 rounded-[1.2rem] px-4 py-2 text-[0.95rem] text-foreground transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-4 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-4 aria-invalid:ring-destructive/20 md:text-sm dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -11,7 +11,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-[0.82rem] leading-none font-semibold tracking-[0.01em] text-slate-700 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 dark:text-slate-200",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -44,7 +44,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "glass-field flex w-full items-center justify-between gap-1.5 rounded-[1.2rem] py-2 pr-3 pl-4 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-4 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-4 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-11 data-[size=sm]:h-9 data-[size=sm]:rounded-full *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:hover:bg-input/70 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -69,7 +69,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}
-        className={cn("relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", position ==="popper"&&"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1", className )}
+        className={cn("glass-panel relative z-50 max-h-(--radix-select-content-available-height) min-w-44 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[1.35rem] bg-popover text-popover-foreground duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", position ==="popper"&&"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1", className )}
         position={position}
         align={align}
         {...props}
@@ -97,7 +97,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      className={cn("px-3 py-2 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground", className)}
       {...props}
     />
   )
@@ -112,7 +112,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-[1rem] px-3 py-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}
@@ -134,7 +134,7 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border/80", className)}
       {...props}
     />
   )

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "glass-field flex field-sizing-content min-h-32 w-full rounded-[1.4rem] px-4 py-3 text-[0.95rem] text-foreground transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-4 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-4 aria-invalid:ring-destructive/20 md:text-sm dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/src/domains/analytics/page/Analytics.jsx
+++ b/src/domains/analytics/page/Analytics.jsx
@@ -6,6 +6,8 @@ import {
 import { TrendingUp, TrendingDown, ShoppingBag, Users, DollarSign, BarChart3 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card.js";
 import { Badge } from "@/components/ui/badge.js";
+import PageIntro from "@/components/layout/PageIntro.jsx";
+import { cn } from "@/lib/utils";
 
 const DAILY = [
   { date: "3/8",  revenue: 320000, orders: 28 },
@@ -35,7 +37,7 @@ const TOP_ITEMS = [
   { name: "제주 한라봉",     sales: 55,  revenue: 715000 },
   { name: "유기농 당근",     sales: 41,  revenue: 369000 },
 ];
-const COLORS = ["rgb(93,171,223)", "rgb(30,157,241)", "rgb(29,161,242)", "rgb(227,236,246)"];
+const COLORS = ["#2563eb", "#38bdf8", "#14b8a6", "#dbeafe"];
 const PERIODS = ["7일", "30일", "90일"];
 
 const TOOLTIP_STYLE = {
@@ -46,7 +48,8 @@ const TOOLTIP_STYLE = {
   color: "var(--foreground)",
 };
 
-function StatCard({ icon: Icon, label, value, sub, trend }) {
+function StatCard({ icon, label, value, sub, trend }) {
+  const Icon = icon;
   const up = trend >= 0;
   return (
     <Card>
@@ -79,22 +82,39 @@ export default function AnalyticsPage() {
   const totalOrders = DAILY.reduce((s, d) => s + d.orders, 0);
 
   return (
-    <div className="max-w-5xl mx-auto">
-      <div className="flex items-start justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold">판매 분석</h1>
-          <p className="text-muted-foreground text-sm mt-1">매출 및 주문 현황을 확인하세요.</p>
+    <div className="mx-auto max-w-6xl space-y-6">
+      <PageIntro
+        eyebrow="Sales Dashboard"
+        title="판매 대시보드"
+        description="매출, 주문, 고객 유입, 카테고리 반응을 한 화면에서 먼저 확인하는 메인 운영 화면입니다. 상세 분석보다 오늘의 상태를 빠르게 읽는 데 초점을 맞췄습니다."
+        meta={[
+          `${(totalRevenue / 10000).toFixed(0)}만원 매출`,
+          `${totalOrders}건 주문`,
+          `${period} 기준`,
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-4 py-4">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+            Period
+          </p>
+          <div className="mt-3 flex gap-2">
+            {PERIODS.map((p) => (
+              <button
+                key={p}
+                onClick={() => setPeriod(p)}
+                className={cn(
+                "flex-1 rounded-full px-3 py-2 text-xs font-semibold transition-all",
+                period === p
+                    ? "bg-primary text-primary-foreground shadow-[0_12px_24px_rgba(29,161,242,0.18)]"
+                    : "bg-white/72 text-muted-foreground hover:bg-accent hover:text-foreground dark:bg-slate-950/38"
+                )}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
         </div>
-        <div className="flex gap-1 bg-muted/50 p-1 rounded-lg border border-border">
-          {PERIODS.map((p) => (
-            <button key={p} onClick={() => setPeriod(p)}
-              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors
-                ${period === p ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"}`}>
-              {p}
-            </button>
-          ))}
-        </div>
-      </div>
+      </PageIntro>
 
       {/* KPI */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">

--- a/src/domains/auth/page/LoginPage.jsx
+++ b/src/domains/auth/page/LoginPage.jsx
@@ -5,6 +5,8 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import {loginAction} from "@/domains/auth/actions/loginAction.js";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 
 
 export default function LoginPage() {
@@ -18,32 +20,27 @@ export default function LoginPage() {
     }, [state.success, navigate])
 
     return (
-        <div className="min-h-screen flex items-center justify-center px-4">
-            <div className="w-full max-w-sm">
+        <div className="reveal-up">
+            <Card className="surface-hero overflow-hidden">
+                <CardContent className="p-6 sm:p-8">
+                    <Badge variant="outline">돈모아 로그인</Badge>
 
-                {/* 로고 / 타이틀 영역 */}
-                <div className="mb-8 text-center">
-                    <h1 className="text-2xl font-bold text-foreground tracking-tight">
-                        로그인
-                    </h1>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                        계정에 로그인하여 서비스를 이용하세요.
-                    </p>
-                </div>
+                    <div className="mt-5 mb-8">
+                        <h1 className="display-title text-4xl font-semibold text-foreground tracking-tight">
+                            로그인
+                        </h1>
+                        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                            계정에 로그인하여 판매 운영 화면으로 진입하세요.
+                        </p>
+                    </div>
 
-                {/* 폼 카드 */}
-                <div className="bg-card border border-border rounded-xl p-6 space-y-5">
-
-                    {/* 서버 에러 알림 */}
                     {state.errors?._form && (
                         <Alert variant="destructive">
                             <AlertDescription>{state.errors._form[0]}</AlertDescription>
                         </Alert>
                     )}
 
-                    <form action={formAction} className="space-y-4">
-
-                        {/* 이메일 */}
+                    <form action={formAction} className="mt-5 space-y-4">
                         <div className="space-y-1.5">
                             <Label htmlFor="email">이메일</Label>
                             <Input
@@ -61,7 +58,6 @@ export default function LoginPage() {
                             )}
                         </div>
 
-                        {/* 비밀번호 */}
                         <div className="space-y-1.5">
                             <div className="flex items-center justify-between">
                                 <Label htmlFor="password">비밀번호</Label>
@@ -87,25 +83,22 @@ export default function LoginPage() {
                             )}
                         </div>
 
-                        {/* 제출 버튼 */}
                         <Button type="submit" className="w-full" disabled={isPending}>
                             {isPending ? "로그인 중..." : "로그인"}
                         </Button>
                     </form>
-                </div>
 
-                {/* 회원가입 링크 */}
-                <p className="mt-5 text-center text-sm text-muted-foreground">
-                    계정이 없으신가요?{" "}
-                    <Link
-                        to="/auth/register"
-                        className="text-primary font-medium hover:underline underline-offset-4 transition-colors"
-                    >
-                        회원가입
-                    </Link>
-                </p>
-
-            </div>
+                    <p className="mt-6 text-center text-sm text-muted-foreground">
+                        계정이 없으신가요?{" "}
+                        <Link
+                            to="/auth/register"
+                            className="text-primary font-medium hover:underline underline-offset-4 transition-colors"
+                        >
+                            회원가입
+                        </Link>
+                    </p>
+                </CardContent>
+            </Card>
         </div>
     )
 }

--- a/src/domains/auth/page/RegisterPage.jsx
+++ b/src/domains/auth/page/RegisterPage.jsx
@@ -5,6 +5,8 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import {registerAction} from "@/domains/auth/actions/RegisterAction.js";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 
 
 export default function RegisterPage() {
@@ -18,36 +20,31 @@ export default function RegisterPage() {
     }, [state.success, navigate])
 
     return (
-        <div className="min-h-screen flex items-center justify-center px-4 py-12">
-            <div className="w-full max-w-sm">
+        <div className="reveal-up">
+            <Card className="surface-hero overflow-hidden">
+                <CardContent className="p-6 sm:p-8">
+                    <Badge variant="outline">돈모아 회원가입</Badge>
 
-                {/* 타이틀 영역 */}
-                <div className="mb-8 text-center">
-                    <h1 className="text-2xl font-bold text-foreground tracking-tight">
-                        회원가입
-                    </h1>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                        계정을 만들고 서비스를 시작하세요.
-                    </p>
-                </div>
+                    <div className="mt-5 mb-8">
+                        <h1 className="display-title text-4xl font-semibold text-foreground tracking-tight">
+                            회원가입
+                        </h1>
+                        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                            운영 계정을 만들고 판매 콘솔을 시작하세요.
+                        </p>
+                    </div>
 
-                {/* 폼 카드 */}
-                <div className="bg-card border border-border rounded-xl p-6 space-y-5">
-
-                    {/* 서버 에러 알림 */}
                     {state.errors?._form && (
                         <Alert variant="destructive">
                             <AlertDescription>{state.errors._form[0]}</AlertDescription>
                         </Alert>
                     )}
 
-                    <form action={formAction} className="space-y-4">
-
-                        {/* 이름 */}
+                    <form action={formAction} className="mt-5 space-y-4">
                         <div className="space-y-1.5">
                             <Label htmlFor="name">이름</Label>
                             <Input
-                                className="placeholder:opacity-20"
+                                className="placeholder:opacity-40"
                                 id="name"
                                 name="name"
                                 type="text"
@@ -62,11 +59,10 @@ export default function RegisterPage() {
                             )}
                         </div>
 
-                        {/* 이메일 */}
                         <div className="space-y-1.5">
                             <Label htmlFor="email">이메일</Label>
                             <Input
-                                className="placeholder:opacity-20"
+                                className="placeholder:opacity-40"
                                 id="email"
                                 name="email"
                                 type="email"
@@ -81,11 +77,10 @@ export default function RegisterPage() {
                             )}
                         </div>
 
-                        {/* 비밀번호 */}
                         <div className="space-y-1.5">
                             <Label htmlFor="password">비밀번호</Label>
                             <Input
-                                className="placeholder:opacity-20"
+                                className="placeholder:opacity-40"
                                 id="password"
                                 name="password"
                                 type="password"
@@ -100,11 +95,10 @@ export default function RegisterPage() {
                             )}
                         </div>
 
-                        {/* 비밀번호 확인 */}
                         <div className="space-y-1.5">
                             <Label htmlFor="passwordConfirm">비밀번호 확인</Label>
                             <Input
-                                className="placeholder:opacity-20"
+                                className="placeholder:opacity-40"
                                 id="passwordConfirm"
                                 name="passwordConfirm"
                                 type="password"
@@ -119,25 +113,22 @@ export default function RegisterPage() {
                             )}
                         </div>
 
-                        {/* 제출 버튼 */}
                         <Button type="submit" className="w-full" disabled={isPending}>
                             {isPending ? "가입 중..." : "회원가입"}
                         </Button>
                     </form>
-                </div>
 
-                {/* 로그인 링크 */}
-                <p className="mt-5 text-center text-sm text-muted-foreground">
-                    이미 계정이 있으신가요?{" "}
-                    <Link
-                        to="/auth/login"
-                        className="text-primary font-medium hover:underline underline-offset-4 transition-colors"
-                    >
-                        로그인
-                    </Link>
-                </p>
-
-            </div>
+                    <p className="mt-6 text-center text-sm text-muted-foreground">
+                        이미 계정이 있으신가요?{" "}
+                        <Link
+                            to="/auth/login"
+                            className="text-primary font-medium hover:underline underline-offset-4 transition-colors"
+                        >
+                            로그인
+                        </Link>
+                    </p>
+                </CardContent>
+            </Card>
         </div>
     )
 }

--- a/src/domains/chat/api/chatApi.js
+++ b/src/domains/chat/api/chatApi.js
@@ -1,0 +1,42 @@
+import apiInstance from "@/common/api/apiInstance.js"
+import {
+  demoFetchChatMessages,
+  demoFetchMyChatRooms,
+  demoSendChatRoomMessage,
+  demoUpdateChatReadPointer,
+  isDemoModeEnabled,
+} from "@/domains/management/mock/demoBackend.js"
+
+export async function fetchMyChatRooms(params = {}) {
+  if (isDemoModeEnabled()) {
+    return demoFetchMyChatRooms(params)
+  }
+  const { data } = await apiInstance.get("/v1/chat/rooms", { params })
+  return data?.data ?? { items: [], nextCursor: null, hasNext: false }
+}
+
+export async function fetchChatMessages(roomId, params = {}) {
+  if (isDemoModeEnabled()) {
+    return demoFetchChatMessages(roomId, params)
+  }
+  const { data } = await apiInstance.get(`/v1/chat/rooms/${roomId}/messages`, { params })
+  return data?.data ?? { items: [], nextCursor: null, hasNext: false }
+}
+
+export async function sendChatRoomMessage(roomId, payload) {
+  if (isDemoModeEnabled()) {
+    return demoSendChatRoomMessage(roomId, payload)
+  }
+  const { data } = await apiInstance.post(`/v1/chat/rooms/${roomId}/messages`, payload)
+  return data?.data ?? null
+}
+
+export async function updateChatReadPointer(roomId, lastReadMessageId) {
+  if (isDemoModeEnabled()) {
+    return demoUpdateChatReadPointer(roomId, lastReadMessageId)
+  }
+  const { data } = await apiInstance.post(`/v1/chat/rooms/${roomId}/read`, {
+    lastReadMessageId,
+  })
+  return data?.data ?? null
+}

--- a/src/domains/chat/hook/useBusinessChatQuery.js
+++ b/src/domains/chat/hook/useBusinessChatQuery.js
@@ -1,0 +1,52 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import {
+  fetchChatMessages,
+  fetchMyChatRooms,
+  sendChatRoomMessage,
+  updateChatReadPointer,
+} from "@/domains/chat/api/chatApi.js"
+
+export function useChatRoomsQuery(params = { size: 20 }) {
+  return useQuery({
+    queryKey: ["business-chat", "rooms", params],
+    queryFn: () => fetchMyChatRooms(params),
+  })
+}
+
+export function useChatMessagesQuery(roomId, params = { size: 50 }) {
+  return useQuery({
+    queryKey: ["business-chat", "messages", roomId, params],
+    queryFn: () => fetchChatMessages(roomId, params),
+    enabled: Boolean(roomId),
+  })
+}
+
+export function useSendChatMessageMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ roomId, payload }) => sendChatRoomMessage(roomId, payload),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["business-chat", "rooms"] })
+      queryClient.invalidateQueries({
+        queryKey: ["business-chat", "messages", variables.roomId],
+      })
+    },
+  })
+}
+
+export function useUpdateChatReadPointerMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ roomId, lastReadMessageId }) =>
+      updateChatReadPointer(roomId, lastReadMessageId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["business-chat", "rooms"] })
+      queryClient.invalidateQueries({
+        queryKey: ["business-chat", "messages", variables.roomId],
+      })
+    },
+  })
+}

--- a/src/domains/chat/page/ChatInbox.jsx
+++ b/src/domains/chat/page/ChatInbox.jsx
@@ -1,0 +1,252 @@
+import { useEffect, useMemo, useState } from "react"
+import { MessageSquareMore, SendHorizonal } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import PageIntro from "@/components/layout/PageIntro.jsx"
+import apiInstance from "@/common/api/apiInstance.js"
+import {
+  useChatMessagesQuery,
+  useChatRoomsQuery,
+  useSendChatMessageMutation,
+  useUpdateChatReadPointerMutation,
+} from "@/domains/chat/hook/useBusinessChatQuery.js"
+import { demoChatMessagesByRoomId, demoChatRooms } from "@/domains/management/mock/demoData.js"
+import { cn } from "@/lib/utils"
+
+function formatDateTime(value) {
+  if (!value) return "-"
+  return String(value).replace("T", " ").slice(0, 16)
+}
+
+function buildDraftClientMessageId() {
+  return `seller-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+export default function ChatInboxPage() {
+  const [selectedRoomId, setSelectedRoomId] = useState("")
+  const [draft, setDraft] = useState("")
+  const currentUserId = String(apiInstance.defaults.headers?.["X-User-Id"] ?? "")
+  const roomsQuery = useChatRoomsQuery({ size: 20 })
+  const sendMessageMutation = useSendChatMessageMutation()
+  const updateReadMutation = useUpdateChatReadPointerMutation()
+
+  const realRooms = useMemo(() => roomsQuery.data?.items ?? [], [roomsQuery.data?.items])
+  const usingDemoChat = import.meta.env.DEV && realRooms.length === 0
+  const rooms = usingDemoChat ? demoChatRooms : realRooms
+  const activeRoomId = rooms.some((room) => String(room.roomId) === String(selectedRoomId))
+    ? String(selectedRoomId)
+    : String(rooms[0]?.roomId ?? "")
+  const selectedRoom = rooms.find((room) => String(room.roomId) === activeRoomId) ?? null
+  const messagesQuery = useChatMessagesQuery(activeRoomId, { size: 50 })
+  const messages = useMemo(() => {
+    if (usingDemoChat) {
+      return demoChatMessagesByRoomId[activeRoomId] ?? []
+    }
+    return messagesQuery.data?.items ?? []
+  }, [activeRoomId, messagesQuery.data?.items, usingDemoChat])
+
+  useEffect(() => {
+    if (usingDemoChat || !activeRoomId || !messages.length) return
+
+    const latestMessage = messages[0]
+    const latestMessageId = latestMessage?.messageId
+    if (!latestMessageId) return
+
+    updateReadMutation.mutate({
+      roomId: activeRoomId,
+      lastReadMessageId: latestMessageId,
+    })
+  }, [activeRoomId, messages, updateReadMutation, usingDemoChat])
+
+  const handleSend = async () => {
+    const content = draft.trim()
+    if (!activeRoomId || !content || usingDemoChat) return
+
+    await sendMessageMutation.mutateAsync({
+      roomId: activeRoomId,
+      payload: {
+        clientMessageId: buildDraftClientMessageId(),
+        messageType: "CHAT",
+        content,
+        metadata: {
+          source: "business-console",
+        },
+      },
+    })
+    setDraft("")
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6">
+      <PageIntro
+        eyebrow="Chat Inbox"
+        title="채팅 문의"
+        description="고객 문의 채팅방을 seller 콘솔 안에서 확인하는 화면입니다. 새 메시지가 온 방을 먼저 보고, 선택한 문의방에서 바로 답장을 보낼 수 있습니다."
+        meta={[
+          `${rooms.length}개 문의방`,
+          selectedRoom ? `${selectedRoom.unreadCount ?? 0}개 미확인` : "문의방 선택 필요",
+          usingDemoChat ? "데모 데이터" : "실데이터",
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Inquiry flow
+          </p>
+          <p className="mt-3 text-lg font-semibold text-foreground">
+            문의방 목록 확인 후 답장
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            실시간 소켓 없이도 현재 문의 이력과 답장 흐름을 운영 화면에서 확인할 수 있습니다.
+          </p>
+        </div>
+      </PageIntro>
+
+      <div className="grid gap-6 xl:grid-cols-[21rem_minmax(0,1fr)]">
+        <Card className="h-fit">
+          <CardContent className="p-5">
+            <div className="flex items-center justify-between">
+              <p className="section-kicker">Rooms</p>
+              {usingDemoChat ? <Badge variant="outline">데모 데이터</Badge> : null}
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {rooms.length > 0 ? (
+                rooms.map((room) => (
+                  <button
+                    key={room.roomId}
+                    type="button"
+                    onClick={() => setSelectedRoomId(String(room.roomId))}
+                    className={cn(
+                      "metric-chip w-full rounded-[1.4rem] px-4 py-4 text-left transition-all",
+                      String(room.roomId) === activeRoomId &&
+                        "border-primary/25 ring-2 ring-primary/12"
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-foreground">
+                          {room.title || room.storeName || "문의 채팅"}
+                        </p>
+                        <p className="mt-1 truncate text-[0.82rem] text-muted-foreground">
+                          {room.buyerDisplayName || room.storeName || "고객"}
+                        </p>
+                      </div>
+                      <Badge variant={room.unreadCount ? "default" : "outline"}>
+                        {room.unreadCount ?? 0}
+                      </Badge>
+                    </div>
+                    <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">
+                      {room.lastMessage?.content ?? "대화 내역이 없습니다."}
+                    </p>
+                    <p className="mt-2 text-[0.78rem] text-slate-500 dark:text-slate-400">
+                      {formatDateTime(room.updatedAt ?? room.lastMessage?.createdAt)}
+                    </p>
+                  </button>
+                ))
+              ) : (
+                <div className="rounded-[1.5rem] border border-dashed border-border px-4 py-8 text-center">
+                  <MessageSquareMore size={20} className="mx-auto text-primary/70" />
+                  <p className="mt-3 text-sm text-muted-foreground">문의 채팅방이 없습니다.</p>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="overflow-hidden">
+          <div className="border-b border-white/70 px-6 py-5 dark:border-slate-800">
+            <p className="section-kicker">Conversation</p>
+            <h2 className="display-title mt-2 text-2xl text-foreground">
+              {selectedRoom?.title || "문의 대화"}
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {selectedRoom
+                ? `${selectedRoom.buyerDisplayName || "고객"} · ${selectedRoom.storeName || "돈모아"}`
+                : "왼쪽에서 문의방을 선택해주세요."}
+            </p>
+          </div>
+
+          <CardContent className="p-6">
+            {!selectedRoom ? (
+              <div className="rounded-[1.8rem] border border-dashed border-border px-6 py-10 text-center">
+                <MessageSquareMore size={24} className="mx-auto text-primary/70" />
+                <p className="mt-3 text-sm text-muted-foreground">문의방을 선택해주세요.</p>
+              </div>
+            ) : messagesQuery.isLoading && !usingDemoChat ? (
+              <div className="rounded-[1.8rem] border border-dashed border-border px-6 py-10 text-center text-sm text-muted-foreground">
+                메시지를 불러오는 중입니다.
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="space-y-3 rounded-[1.6rem] border border-border/80 bg-white/55 p-4 dark:bg-slate-950/20">
+                  {messages.length > 0 ? (
+                    messages
+                      .slice()
+                      .reverse()
+                      .map((message) => {
+                        const isMine =
+                          currentUserId && String(message.senderId) === currentUserId
+
+                        return (
+                          <div
+                            key={message.messageId}
+                            className={cn("flex", isMine ? "justify-end" : "justify-start")}
+                          >
+                            <div className={cn("max-w-[80%] space-y-1", isMine && "text-right")}>
+                              <div
+                                className={cn(
+                                  "rounded-2xl px-3 py-2 text-sm leading-relaxed",
+                                  isMine
+                                    ? "bg-primary text-primary-foreground"
+                                    : "border border-border bg-card text-foreground"
+                                )}
+                              >
+                                {message.content}
+                              </div>
+                              <p className="text-[0.74rem] text-muted-foreground">
+                                {formatDateTime(message.createdAt)}
+                              </p>
+                            </div>
+                          </div>
+                        )
+                      })
+                  ) : (
+                    <div className="py-10 text-center text-sm text-muted-foreground">
+                      아직 메시지가 없습니다.
+                    </div>
+                  )}
+                </div>
+
+                <div className="rounded-[1.6rem] border border-border/80 bg-white/55 p-4 dark:bg-slate-950/20">
+                  <Textarea
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    placeholder={
+                      usingDemoChat
+                        ? "데모 데이터에서는 답장을 전송할 수 없습니다."
+                        : "문의 답장을 입력하세요"
+                    }
+                    rows={4}
+                    disabled={!selectedRoom || usingDemoChat || sendMessageMutation.isPending}
+                  />
+                  <div className="mt-3 flex justify-end">
+                    <Button
+                      onClick={handleSend}
+                      disabled={!draft.trim() || !selectedRoom || usingDemoChat || sendMessageMutation.isPending}
+                    >
+                      <SendHorizonal size={14} />
+                      {sendMessageMutation.isPending ? "전송 중..." : "답장 보내기"}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/domains/funding/api/fundingApi.js
+++ b/src/domains/funding/api/fundingApi.js
@@ -7,6 +7,7 @@ import {
   demoGetCampaignByItemId,
   demoGetCampaignProgress,
   demoGetCampaigns,
+  demoUpdateCampaign,
   isDemoModeEnabled,
 } from "@/domains/management/mock/demoBackend.js"
 
@@ -23,6 +24,9 @@ export async function createCampaign(payload) {
 }
 
 export async function updateCampaign(campaignId, payload) {
+  if (isDemoModeEnabled()) {
+    return demoUpdateCampaign(campaignId, payload)
+  }
   try {
     const response = await apiInstance.put(`/campaigns/${campaignId}`, payload)
     return unwrapApiResponseBody(response, "펀딩 캠페인 수정에 실패했습니다.")

--- a/src/domains/funding/api/fundingApi.js
+++ b/src/domains/funding/api/fundingApi.js
@@ -1,37 +1,93 @@
 import apiInstance from "@/common/api/apiInstance.js"
+import { normalizeApiError, unwrapApiResponseBody } from "@/common/api/responseUtils.js"
+import {
+  demoCancelCampaign,
+  demoCreateCampaign,
+  demoGetCampaignById,
+  demoGetCampaignByItemId,
+  demoGetCampaignProgress,
+  demoGetCampaigns,
+  isDemoModeEnabled,
+} from "@/domains/management/mock/demoBackend.js"
 
 export async function createCampaign(payload) {
-  const { data } = await apiInstance.post("/campaigns", payload)
-  return data
+  if (isDemoModeEnabled()) {
+    return demoCreateCampaign(payload)
+  }
+  try {
+    const response = await apiInstance.post("/campaigns", payload)
+    return unwrapApiResponseBody(response, "펀딩 캠페인 생성에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "펀딩 캠페인 생성에 실패했습니다.")
+  }
 }
 
 export async function updateCampaign(campaignId, payload) {
-  const { data } = await apiInstance.put(`/campaigns/${campaignId}`, payload)
-  return data
+  try {
+    const response = await apiInstance.put(`/campaigns/${campaignId}`, payload)
+    return unwrapApiResponseBody(response, "펀딩 캠페인 수정에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "펀딩 캠페인 수정에 실패했습니다.")
+  }
 }
 
 export async function cancelCampaign(campaignId, reason) {
-  const params = reason ? { reason } : {}
-  const { data } = await apiInstance.post(`/campaigns/${campaignId}/cancel`, null, { params })
-  return data
+  if (isDemoModeEnabled()) {
+    return demoCancelCampaign(campaignId, reason)
+  }
+  try {
+    const params = reason ? { reason } : {}
+    const response = await apiInstance.post(`/campaigns/${campaignId}/cancel`, null, { params })
+    return unwrapApiResponseBody(response, "펀딩 캠페인 취소에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "펀딩 캠페인 취소에 실패했습니다.")
+  }
 }
 
 export async function getCampaigns(params = {}) {
-  const { data } = await apiInstance.get("/campaigns", { params })
-  return data?.data ?? { content: [], nextCursor: null }
+  if (isDemoModeEnabled()) {
+    return demoGetCampaigns(params)
+  }
+  try {
+    const response = await apiInstance.get("/campaigns", { params })
+    return unwrapApiResponseBody(response, "펀딩 캠페인 목록을 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "펀딩 캠페인 목록 조회에 실패했습니다.")
+  }
 }
 
 export async function getCampaignById(campaignId) {
-  const { data } = await apiInstance.get(`/campaigns/${campaignId}`)
-  return data?.data ?? null
+  if (isDemoModeEnabled()) {
+    return demoGetCampaignById(campaignId)
+  }
+  try {
+    const response = await apiInstance.get(`/campaigns/${campaignId}`)
+    return unwrapApiResponseBody(response, "펀딩 캠페인 정보를 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "펀딩 캠페인 조회에 실패했습니다.")
+  }
 }
 
 export async function getCampaignByItemId(itemId) {
-  const { data } = await apiInstance.get(`/campaigns/item/${itemId}`)
-  return data?.data ?? null
+  if (isDemoModeEnabled()) {
+    return demoGetCampaignByItemId(itemId)
+  }
+  try {
+    const response = await apiInstance.get(`/campaigns/item/${itemId}`)
+    return unwrapApiResponseBody(response, "상품별 펀딩 정보를 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "상품별 펀딩 조회에 실패했습니다.")
+  }
 }
 
 export async function getCampaignProgress(campaignId) {
-  const { data } = await apiInstance.get(`/campaigns/${campaignId}/progress`)
-  return data?.data ?? null
+  if (isDemoModeEnabled()) {
+    return demoGetCampaignProgress(campaignId)
+  }
+  try {
+    const response = await apiInstance.get(`/campaigns/${campaignId}/progress`)
+    return unwrapApiResponseBody(response, "펀딩 진행률을 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "펀딩 진행률 조회에 실패했습니다.")
+  }
 }

--- a/src/domains/funding/hook/useFundingQuery.js
+++ b/src/domains/funding/hook/useFundingQuery.js
@@ -1,38 +1,62 @@
 import { useQuery } from "@tanstack/react-query"
+import { shouldRetryRequest } from "@/common/api/queryRetry.js"
 import {
   getCampaigns,
   getCampaignById,
   getCampaignByItemId,
   getCampaignProgress,
 } from "../api/fundingApi.js"
+import {
+  mapFundingCampaignListPayload,
+  mapFundingCampaignPayload,
+  mapFundingProgressPayload,
+} from "../lib/fundingMappers.js"
+
+export const fundingKeys = {
+  all: ["funding"],
+  lists: () => [...fundingKeys.all, "list"],
+  list: (params) => [...fundingKeys.lists(), params],
+  details: () => [...fundingKeys.all, "detail"],
+  detail: (campaignId) => [...fundingKeys.details(), campaignId],
+  item: (itemId) => [...fundingKeys.all, "item", itemId],
+  progress: (campaignId) => [...fundingKeys.all, campaignId, "progress"],
+}
 
 export function useCampaignsQuery(params = {}) {
   return useQuery({
-    queryKey: ["campaigns", params],
-    queryFn: () => getCampaigns(params),
+    queryKey: fundingKeys.list(params),
+    queryFn: async () => mapFundingCampaignListPayload(await getCampaigns(params)),
+    retry: shouldRetryRequest,
+    staleTime: 30_000,
   })
 }
 
 export function useCampaignQuery(campaignId) {
   return useQuery({
-    queryKey: ["campaigns", campaignId],
-    queryFn: () => getCampaignById(campaignId),
+    queryKey: fundingKeys.detail(campaignId),
+    queryFn: async () => mapFundingCampaignPayload(await getCampaignById(campaignId)),
     enabled: !!campaignId,
+    retry: shouldRetryRequest,
+    staleTime: 30_000,
   })
 }
 
 export function useCampaignByItemQuery(itemId) {
   return useQuery({
-    queryKey: ["campaigns", "item", itemId],
-    queryFn: () => getCampaignByItemId(itemId),
+    queryKey: fundingKeys.item(itemId),
+    queryFn: async () => mapFundingCampaignPayload(await getCampaignByItemId(itemId)),
     enabled: !!itemId,
+    retry: shouldRetryRequest,
+    staleTime: 30_000,
   })
 }
 
 export function useCampaignProgressQuery(campaignId) {
   return useQuery({
-    queryKey: ["campaigns", campaignId, "progress"],
-    queryFn: () => getCampaignProgress(campaignId),
+    queryKey: fundingKeys.progress(campaignId),
+    queryFn: async () => mapFundingProgressPayload(await getCampaignProgress(campaignId)),
     enabled: !!campaignId,
+    retry: shouldRetryRequest,
+    staleTime: 10_000,
   })
 }

--- a/src/domains/funding/lib/fundingMappers.js
+++ b/src/domains/funding/lib/fundingMappers.js
@@ -1,0 +1,149 @@
+const currencyFormatter = new Intl.NumberFormat("ko-KR")
+
+function toNumber(value, fallback = 0) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function toNullableNumber(value) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+function toText(value, fallback = "") {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim()
+  }
+
+  return fallback
+}
+
+function toId(value, fallback = null) {
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  const normalized = String(value).trim()
+  return normalized || fallback
+}
+
+function formatPrice(value) {
+  const number = toNullableNumber(value)
+
+  if (number === null) {
+    return value ? String(value) : "-"
+  }
+
+  return `${currencyFormatter.format(number)}원`
+}
+
+function mapFundingStatus(status) {
+  switch (String(status || "").toUpperCase()) {
+    case "ACTIVE":
+      return "진행 중"
+    case "SUCCEEDED":
+      return "달성 완료"
+    case "FAILED":
+      return "실패"
+    case "CANCELLED":
+      return "취소됨"
+    default:
+      return status ? String(status) : "상태 미정"
+  }
+}
+
+function computeProgress(raw = {}) {
+  const fundingType = toText(raw?.fundingType, "AMOUNT_BASED").toUpperCase()
+
+  if (fundingType === "QUANTITY_BASED") {
+    const current = toNumber(raw?.currentQuantity, 0)
+    const goal = toNumber(raw?.goalQuantity, 0)
+    const progressRate = goal > 0 ? Math.min(100, Math.round((current / goal) * 100)) : 0
+
+    return {
+      currentQuantity: current,
+      goalQuantity: goal,
+      progressRate,
+      progressLabel: `${current.toLocaleString()} / ${goal.toLocaleString()}개`,
+    }
+  }
+
+  const current = toNumber(raw?.currentAmount, 0)
+  const goal = toNumber(raw?.goalAmount, 0)
+  const progressRate = goal > 0 ? Math.min(100, Math.round((current / goal) * 100)) : 0
+
+  return {
+    currentAmount: current,
+    goalAmount: goal,
+    progressRate,
+    progressLabel: `${formatPrice(current)} / ${formatPrice(goal)}`,
+  }
+}
+
+function mapCampaign(raw = {}) {
+  const fundingType = toText(raw?.fundingType, "AMOUNT_BASED").toUpperCase()
+  const progress = computeProgress({ ...raw, fundingType })
+
+  return {
+    id: toId(raw?.campaignId ?? raw?.id),
+    itemId: toId(raw?.itemId),
+    sellerId: toId(raw?.sellerId),
+    title: toText(raw?.title, "제목 없는 펀딩"),
+    summary: toText(raw?.summary),
+    makerName: toText(raw?.makerName, "메이커 정보 준비 중"),
+    category: toText(raw?.category, "기타"),
+    fundingType,
+    statusCode: toText(raw?.status, "").toUpperCase(),
+    status: mapFundingStatus(raw?.status),
+    startAt: raw?.startAt ?? null,
+    endAt: raw?.endAt ?? null,
+    currentAmount: progress.currentAmount ?? toNullableNumber(raw?.currentAmount),
+    currentAmountText: formatPrice(raw?.currentAmount),
+    goalAmount: progress.goalAmount ?? toNullableNumber(raw?.goalAmount),
+    goalAmountText: formatPrice(raw?.goalAmount),
+    currentQuantity: progress.currentQuantity ?? toNullableNumber(raw?.currentQuantity),
+    goalQuantity: progress.goalQuantity ?? toNullableNumber(raw?.goalQuantity),
+    minAmount: toNullableNumber(raw?.minAmount),
+    progressRate: progress.progressRate,
+    progressLabel: progress.progressLabel,
+    createdAt: raw?.createdAt ?? null,
+    updatedAt: raw?.updatedAt ?? null,
+  }
+}
+
+export function mapFundingCampaignListPayload(payload) {
+  const items = Array.isArray(payload?.items)
+    ? payload.items
+    : Array.isArray(payload?.content)
+      ? payload.content
+      : Array.isArray(payload)
+        ? payload
+        : []
+
+  return {
+    items: items.map(mapCampaign),
+    nextCursor: payload?.nextCursor ?? null,
+    hasNext: Boolean(payload?.hasNext ?? payload?.nextCursor),
+    totalCount: payload?.totalCount ?? items.length,
+  }
+}
+
+export function mapFundingCampaignPayload(payload) {
+  if (!payload) {
+    return null
+  }
+
+  return mapCampaign(payload)
+}
+
+export function mapFundingProgressPayload(payload = {}) {
+  const progressRate = toNullableNumber(payload?.progressRate)
+
+  return {
+    currentAmount: toNullableNumber(payload?.currentAmount),
+    goalAmount: toNullableNumber(payload?.goalAmount),
+    currentQuantity: toNullableNumber(payload?.currentQuantity),
+    goalQuantity: toNullableNumber(payload?.goalQuantity),
+    progressRate: progressRate ?? 0,
+  }
+}

--- a/src/domains/funding/page/Funding.jsx
+++ b/src/domains/funding/page/Funding.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useActionState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { AlertCircle, DollarSign, Hash, Check, Ban } from "lucide-react"
+import { Link } from "react-router"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -34,10 +35,11 @@ function FundingForm({ onReset }) {
   const { data: productsPayload } = useSellerProductsQuery();
   const products = productsPayload?.items ?? []
   const { data: campaignPage } = useCampaignsQuery()
-  const usingDemoFunding = import.meta.env.DEV && products.length === 0 && (campaignPage?.content ?? []).length === 0
+  const campaignItems = campaignPage?.items ?? []
+  const usingDemoFunding = import.meta.env.DEV && products.length === 0 && campaignItems.length === 0
   const sourceProducts = usingDemoFunding ? demoItems : products
   const sellerItemIds = new Set(sourceProducts.map((product) => String(product.id)))
-  const campaigns = (usingDemoFunding ? demoCampaigns : (campaignPage?.content ?? [])).filter((campaign) =>
+  const campaigns = (usingDemoFunding ? demoCampaigns : campaignItems).filter((campaign) =>
     sellerItemIds.has(String(campaign.itemId))
   )
   const cancelMutation = useMutation({
@@ -190,6 +192,9 @@ function FundingForm({ onReset }) {
                     ) : null}
 
                     <div className="mt-5 flex flex-wrap gap-2">
+                      <Button asChild size="sm" variant="outline">
+                        <Link to={`/business/funding/${campaign.id}`}>상세/수정</Link>
+                      </Button>
                       {isActive ? (
                         <Button
                           size="sm"

--- a/src/domains/funding/page/Funding.jsx
+++ b/src/domains/funding/page/Funding.jsx
@@ -1,11 +1,29 @@
 import { useState, useEffect, useActionState } from "react"
-import { useQueryClient } from "@tanstack/react-query"
-import { DollarSign, Hash, Check } from "lucide-react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { AlertCircle, DollarSign, Hash, Check, Ban } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 import { createCampaignAction } from "../actions/createFundingAction.js"
 import { useSellerProductsQuery } from "@/domains/items/hook/useItemsQuery.js"
+import { fundingKeys, useCampaignsQuery } from "../hook/useFundingQuery.js"
+import { cancelCampaign } from "../api/fundingApi.js"
 import FundingFormFields from "@/components/funding/FundingFormFields.jsx"
+import PageIntro from "@/components/layout/PageIntro.jsx"
+import { demoCampaigns, demoItems } from "@/domains/management/mock/demoData.js"
+import { cn } from "@/lib/utils"
+
+const FUNDING_STATUS_META = {
+  ACTIVE: { label: "진행 중", variant: "default" },
+  SUCCEEDED: { label: "달성 완료", variant: "secondary" },
+  FAILED: { label: "실패", variant: "destructive" },
+  CANCELLED: { label: "취소됨", variant: "outline" },
+}
+
+function getCampaignStatusMeta(status) {
+  return FUNDING_STATUS_META[status] ?? { label: status, variant: "outline" }
+}
 
 function FundingForm({ onReset }) {
   const [fundingType, setFundingType] = useState("AMOUNT_BASED")
@@ -13,67 +31,244 @@ function FundingForm({ onReset }) {
   const queryClient = useQueryClient()
 
   const [state, formAction, isPending] = useActionState(createCampaignAction, {})
-  const { data: products = [] } = useSellerProductsQuery();
-  console.log("products", products);
+  const { data: productsPayload } = useSellerProductsQuery();
+  const products = productsPayload?.items ?? []
+  const { data: campaignPage } = useCampaignsQuery()
+  const usingDemoFunding = import.meta.env.DEV && products.length === 0 && (campaignPage?.content ?? []).length === 0
+  const sourceProducts = usingDemoFunding ? demoItems : products
+  const sellerItemIds = new Set(sourceProducts.map((product) => String(product.id)))
+  const campaigns = (usingDemoFunding ? demoCampaigns : (campaignPage?.content ?? [])).filter((campaign) =>
+    sellerItemIds.has(String(campaign.itemId))
+  )
+  const cancelMutation = useMutation({
+    mutationFn: ({ campaignId, reason }) => cancelCampaign(campaignId, reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: fundingKeys.lists() })
+    },
+  })
 
   useEffect(() => {
     if (state.success) {
-      queryClient.invalidateQueries({ queryKey: ["campaigns"] })
+      queryClient.invalidateQueries({ queryKey: fundingKeys.lists() })
     }
   }, [state.success, queryClient])
 
+  const handleCancelCampaign = (campaign) => {
+    if (!window.confirm(`"${campaign.title}" 캠페인을 취소하시겠습니까?`)) {
+      return
+    }
+    cancelMutation.mutate({ campaignId: campaign.id, reason: "seller-console" })
+  }
+
   if (state.success) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
-          <Check size={32} className="text-primary" />
+      <div className="mx-auto flex min-h-[60vh] max-w-xl items-center justify-center">
+        <div className="glass-panel surface-hero flex w-full flex-col items-center gap-4 rounded-[2rem] px-8 py-12 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/12">
+            <Check size={32} className="text-primary" />
+          </div>
+          <h2 className="display-title text-3xl font-semibold">펀딩 캠페인 생성 완료!</h2>
+          <p className="max-w-md text-sm leading-6 text-muted-foreground">
+            펀딩 캠페인이 성공적으로 등록되었습니다. 같은 톤의 운영 플로우에서 다른 아이템도 연이어 설정할 수 있습니다.
+          </p>
+          <Button onClick={onReset}>다시 등록하기</Button>
         </div>
-        <h2 className="text-xl font-bold">펀딩 캠페인 생성 완료!</h2>
-        <p className="text-muted-foreground text-sm">펀딩 캠페인이 성공적으로 등록되었습니다.</p>
-        <Button onClick={onReset}>다시 등록하기</Button>
       </div>
     )
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold">펀딩 설정</h1>
-        <p className="text-muted-foreground text-sm mt-1">가게 펀딩 캠페인을 등록하세요.</p>
-      </div>
+    <div className="mx-auto max-w-6xl space-y-6">
+      <PageIntro
+        eyebrow="Funding Management"
+        title="펀딩 관리"
+        description="금액 기반과 수량 기반 방식을 한 인터페이스에서 전환하며 운영할 수 있도록 정리했습니다. 목표와 기간, 메이커 정보까지 같은 흐름으로 묶었습니다."
+        meta={[
+          fundingType === "AMOUNT_BASED" ? "금액 기반" : "수량 기반",
+          `연결 가능한 아이템 ${products.length}개`,
+          `${campaigns.length}개 캠페인 관리`,
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Campaign mode
+          </p>
+          <p className="mt-3 text-lg font-semibold text-foreground">
+            {fundingType === "AMOUNT_BASED" ? "목표 금액 중심" : "목표 수량 중심"}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            선택한 타입에 따라 핵심 KPI만 강조해 보여줍니다.
+          </p>
+        </div>
+      </PageIntro>
 
-      <Card className="bg-card border border-border rounded-xl overflow-hidden">
-        <div className="flex items-center gap-2 px-6 py-4 border-b border-border">
-          <div className="w-1 h-4 bg-primary rounded-full" />
-          <h3 className="font-semibold text-sm">펀딩 캠페인 등록</h3>
+      <Card className="overflow-hidden">
+        <div className="flex flex-col gap-4 border-b border-white/70 px-6 py-5 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="section-kicker">Current campaigns</p>
+            <h2 className="display-title mt-2 text-2xl text-foreground">설정된 펀딩</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              진행 중이거나 종료된 펀딩 현황을 먼저 확인한 뒤, 새 캠페인을 추가합니다.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {usingDemoFunding ? <Badge variant="outline">데모 데이터</Badge> : null}
+            <Badge variant="outline">{campaigns.length}개 캠페인</Badge>
+          </div>
         </div>
 
-        <div className="px-6 py-6">
-          <div className="flex gap-2 p-1 bg-muted rounded-lg w-full mb-6">
+        <CardContent className="p-6">
+          {campaigns.length > 0 ? (
+            <div className="grid gap-4 lg:grid-cols-2">
+              {campaigns.map((campaign) => {
+                const statusMeta = getCampaignStatusMeta(campaign.statusCode)
+                const linkedItem =
+                  products.find((product) => String(product.id) === String(campaign.itemId))
+                const isActive = campaign.statusCode === "ACTIVE"
+
+                return (
+                  <div key={campaign.id} className="metric-chip rounded-[1.6rem] px-5 py-5">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-base font-semibold text-foreground">
+                          {campaign.title}
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          <Badge variant={statusMeta.variant}>{statusMeta.label}</Badge>
+                          <Badge variant="outline">
+                            {campaign.fundingType === "QUANTITY_BASED" ? "수량 기반" : "금액 기반"}
+                          </Badge>
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-[0.72rem] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                          Item
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {linkedItem?.title ?? `#${campaign.itemId}`}
+                        </p>
+                      </div>
+                    </div>
+
+                      <div className="mt-4">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="text-muted-foreground">진행률</span>
+                        <span className="font-semibold text-foreground">{campaign.progressLabel}</span>
+                      </div>
+                      <div className="mt-2 h-2 rounded-full bg-muted/70">
+                        <div
+                          className="h-full rounded-full bg-primary"
+                          style={{ width: `${campaign.progressRate}%` }}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                      <div>
+                        <p className="text-[0.72rem] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                          기간
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {campaign.startAt?.slice?.(0, 10) ?? "-"} ~ {campaign.endAt?.slice?.(0, 10) ?? "-"}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-[0.72rem] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                          메이커
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {campaign.makerName ?? "-"}
+                        </p>
+                      </div>
+                    </div>
+
+                    {campaign.summary ? (
+                      <p className="mt-4 line-clamp-2 text-sm leading-6 text-muted-foreground">
+                        {campaign.summary}
+                      </p>
+                    ) : null}
+
+                    <div className="mt-5 flex flex-wrap gap-2">
+                      {isActive ? (
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={() => handleCancelCampaign(campaign)}
+                          disabled={cancelMutation.isPending || usingDemoFunding}
+                        >
+                          <Ban size={14} />
+                          캠페인 취소
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="rounded-[1.8rem] border border-dashed border-border px-6 py-10 text-center">
+              <AlertCircle size={24} className="mx-auto text-primary/70" />
+              <h3 className="mt-4 text-lg font-semibold text-foreground">
+                아직 등록된 펀딩 캠페인이 없습니다
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                아래 폼에서 첫 캠페인을 바로 추가할 수 있습니다.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {!usingDemoFunding && cancelMutation.isError && (
+        <Alert variant="destructive">
+          <AlertDescription>펀딩 캠페인 취소에 실패했습니다.</AlertDescription>
+        </Alert>
+      )}
+
+      <Card className="overflow-hidden">
+        <div className="flex flex-col gap-4 border-b border-white/70 px-6 py-5 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="section-kicker">Create campaign</p>
+            <h2 className="display-title mt-2 text-2xl text-foreground">새 펀딩 등록</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              기존 캠페인과 별도로 새로운 펀딩을 추가할 때만 이 폼을 사용합니다.
+            </p>
+          </div>
+
+          <div className="metric-chip flex w-full max-w-md gap-2 rounded-full p-1.5">
             <button
               type="button"
               onClick={() => setFundingType("AMOUNT_BASED")}
-              className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-colors ${
+              className={cn(
+                "flex-1 rounded-full px-4 py-2.5 text-sm font-semibold transition-all",
                 fundingType === "AMOUNT_BASED"
-                  ? "bg-primary text-primary-foreground shadow-sm"
+                  ? "bg-primary text-primary-foreground shadow-[0_12px_24px_rgba(29,161,242,0.18)]"
                   : "text-muted-foreground hover:text-foreground"
-              }`}
+              )}
             >
-              <DollarSign size={14} /> 금액 기반
+              <span className="flex items-center justify-center gap-2">
+                <DollarSign size={15} /> 금액 기반
+              </span>
             </button>
             <button
               type="button"
               onClick={() => setFundingType("QUANTITY_BASED")}
-              className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-colors ${
+              className={cn(
+                "flex-1 rounded-full px-4 py-2.5 text-sm font-semibold transition-all",
                 fundingType === "QUANTITY_BASED"
-                  ? "bg-primary text-primary-foreground shadow-sm"
+                  ? "bg-primary text-primary-foreground shadow-[0_12px_24px_rgba(29,161,242,0.18)]"
                   : "text-muted-foreground hover:text-foreground"
-              }`}
+              )}
             >
-              <Hash size={14} /> 수량 기반
+              <span className="flex items-center justify-center gap-2">
+                <Hash size={15} /> 수량 기반
+              </span>
             </button>
           </div>
+        </div>
 
+        <div className="px-6 py-6">
           <FundingFormFields
             state={state}
             formAction={formAction}
@@ -81,7 +276,7 @@ function FundingForm({ onReset }) {
             fundingType={fundingType}
             itemId={itemId}
             setItemId={setItemId}
-            products={products}
+            products={sourceProducts}
           />
         </div>
       </Card>

--- a/src/domains/funding/page/FundingDetail.jsx
+++ b/src/domains/funding/page/FundingDetail.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { Link, useParams } from "react-router"
 import { Ban, Save } from "lucide-react"
@@ -14,27 +14,23 @@ import { fundingKeys, useCampaignQuery } from "@/domains/funding/hook/useFunding
 import { cancelCampaign, updateCampaign } from "@/domains/funding/api/fundingApi.js"
 import PageIntro from "@/components/layout/PageIntro.jsx"
 
-export default function FundingDetailPage() {
-  const { campaignId } = useParams()
-  const queryClient = useQueryClient()
-  const detailQuery = useCampaignQuery(campaignId)
-  const campaign = detailQuery.data
-  const [form, setForm] = useState(null)
+function buildCampaignForm(campaign) {
+  return {
+    title: campaign.title ?? "",
+    summary: campaign.summary ?? "",
+    makerName: campaign.makerName ?? "",
+    category: campaign.category ?? "",
+    goalAmount: String(campaign.goalAmount ?? 0),
+    goalQuantity: campaign.goalQuantity ? String(campaign.goalQuantity) : "",
+    minAmount: campaign.minAmount ? String(campaign.minAmount) : "",
+    startAt: campaign.startAt?.slice?.(0, 16) ?? "",
+    endAt: campaign.endAt?.slice?.(0, 16) ?? "",
+  }
+}
 
-  useEffect(() => {
-    if (!campaign) return
-    setForm({
-      title: campaign.title ?? "",
-      summary: campaign.summary ?? "",
-      makerName: campaign.makerName ?? "",
-      category: campaign.category ?? "",
-      goalAmount: String(campaign.goalAmount ?? 0),
-      goalQuantity: campaign.goalQuantity ? String(campaign.goalQuantity) : "",
-      minAmount: campaign.minAmount ? String(campaign.minAmount) : "",
-      startAt: campaign.startAt?.slice?.(0, 16) ?? "",
-      endAt: campaign.endAt?.slice?.(0, 16) ?? "",
-    })
-  }, [campaign])
+function FundingDetailEditor({ campaign, campaignId }) {
+  const queryClient = useQueryClient()
+  const [form, setForm] = useState(() => buildCampaignForm(campaign))
 
   const updateMutation = useMutation({
     mutationFn: (payload) => updateCampaign(campaignId, payload),
@@ -75,52 +71,8 @@ export default function FundingDetailPage() {
     await cancelMutation.mutateAsync("seller-console")
   }
 
-  if (detailQuery.isLoading || !form) {
-    return (
-      <div className="mx-auto flex min-h-[40vh] max-w-3xl items-center justify-center">
-        <div className="glass-panel rounded-[1.8rem] px-6 py-8 text-center text-sm text-muted-foreground">
-          펀딩 상세를 불러오는 중입니다.
-        </div>
-      </div>
-    )
-  }
-
-  if (!campaign) {
-    return (
-      <div className="mx-auto max-w-3xl">
-        <Alert variant="destructive">
-          <AlertDescription>펀딩 상세를 찾을 수 없습니다.</AlertDescription>
-        </Alert>
-      </div>
-    )
-  }
-
   return (
-    <div className="mx-auto max-w-5xl space-y-6">
-      <PageIntro
-        eyebrow="Funding Detail"
-        title={campaign.title}
-        description="펀딩 상세와 수정 화면입니다. 기본 설정을 조정하고 진행 중인 캠페인은 여기서 취소할 수 있습니다."
-        meta={[campaign.status, campaign.fundingType, campaign.progressLabel]}
-      >
-        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
-          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
-            Quick actions
-          </p>
-          <div className="mt-3 flex flex-wrap gap-2">
-            <Button asChild size="sm" variant="outline">
-              <Link to="/business/funding">목록으로</Link>
-            </Button>
-            {campaign.statusCode === "ACTIVE" ? (
-              <Button size="sm" variant="destructive" onClick={handleCancel} disabled={cancelMutation.isPending}>
-                <Ban size={14} />
-                캠페인 취소
-              </Button>
-            ) : null}
-          </div>
-        </div>
-      </PageIntro>
-
+    <>
       {(updateMutation.error || cancelMutation.error) ? (
         <Alert variant="destructive">
           <AlertDescription>
@@ -172,7 +124,13 @@ export default function FundingDetailPage() {
             </div>
           </div>
 
-          <div className="mt-6 flex justify-end">
+          <div className="mt-6 flex justify-end gap-2">
+            {campaign.statusCode === "ACTIVE" ? (
+              <Button size="sm" variant="destructive" onClick={handleCancel} disabled={cancelMutation.isPending}>
+                <Ban size={14} />
+                캠페인 취소
+              </Button>
+            ) : null}
             <Button onClick={handleSubmit} disabled={updateMutation.isPending}>
               <Save size={14} />
               {updateMutation.isPending ? "저장 중..." : "변경 저장"}
@@ -180,6 +138,54 @@ export default function FundingDetailPage() {
           </div>
         </CardContent>
       </Card>
+    </>
+  )
+}
+
+export default function FundingDetailPage() {
+  const { campaignId } = useParams()
+  const detailQuery = useCampaignQuery(campaignId)
+  const campaign = detailQuery.data
+  if (detailQuery.isLoading || !campaign) {
+    return (
+      <div className="mx-auto flex min-h-[40vh] max-w-3xl items-center justify-center">
+        <div className="glass-panel rounded-[1.8rem] px-6 py-8 text-center text-sm text-muted-foreground">
+          펀딩 상세를 불러오는 중입니다.
+        </div>
+      </div>
+    )
+  }
+
+  if (!campaign) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <Alert variant="destructive">
+          <AlertDescription>펀딩 상세를 찾을 수 없습니다.</AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <PageIntro
+        eyebrow="Funding Detail"
+        title={campaign.title}
+        description="펀딩 상세와 수정 화면입니다. 기본 설정을 조정하고 진행 중인 캠페인은 여기서 취소할 수 있습니다."
+        meta={[campaign.status, campaign.fundingType, campaign.progressLabel]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Quick actions
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button asChild size="sm" variant="outline">
+              <Link to="/business/funding">목록으로</Link>
+            </Button>
+          </div>
+        </div>
+      </PageIntro>
+      <FundingDetailEditor key={`${campaign.id}-${campaign.updatedAt ?? ""}`} campaign={campaign} campaignId={campaignId} />
     </div>
   )
 }

--- a/src/domains/funding/page/FundingDetail.jsx
+++ b/src/domains/funding/page/FundingDetail.jsx
@@ -1,0 +1,185 @@
+import { useEffect, useState } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { Link, useParams } from "react-router"
+import { Ban, Save } from "lucide-react"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { fundingKeys, useCampaignQuery } from "@/domains/funding/hook/useFundingQuery.js"
+import { cancelCampaign, updateCampaign } from "@/domains/funding/api/fundingApi.js"
+import PageIntro from "@/components/layout/PageIntro.jsx"
+
+export default function FundingDetailPage() {
+  const { campaignId } = useParams()
+  const queryClient = useQueryClient()
+  const detailQuery = useCampaignQuery(campaignId)
+  const campaign = detailQuery.data
+  const [form, setForm] = useState(null)
+
+  useEffect(() => {
+    if (!campaign) return
+    setForm({
+      title: campaign.title ?? "",
+      summary: campaign.summary ?? "",
+      makerName: campaign.makerName ?? "",
+      category: campaign.category ?? "",
+      goalAmount: String(campaign.goalAmount ?? 0),
+      goalQuantity: campaign.goalQuantity ? String(campaign.goalQuantity) : "",
+      minAmount: campaign.minAmount ? String(campaign.minAmount) : "",
+      startAt: campaign.startAt?.slice?.(0, 16) ?? "",
+      endAt: campaign.endAt?.slice?.(0, 16) ?? "",
+    })
+  }, [campaign])
+
+  const updateMutation = useMutation({
+    mutationFn: (payload) => updateCampaign(campaignId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: fundingKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: fundingKeys.detail(campaignId) })
+    },
+  })
+
+  const cancelMutation = useMutation({
+    mutationFn: (reason) => cancelCampaign(campaignId, reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: fundingKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: fundingKeys.detail(campaignId) })
+    },
+  })
+
+  const handleChange = (name, value) => {
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async () => {
+    await updateMutation.mutateAsync({
+      title: form.title || undefined,
+      summary: form.summary || undefined,
+      makerName: form.makerName || undefined,
+      category: form.category || undefined,
+      goalAmount: Number(form.goalAmount || 0),
+      goalQuantity: form.goalQuantity ? Number(form.goalQuantity) : undefined,
+      minAmount: form.minAmount ? Number(form.minAmount) : undefined,
+      startAt: form.startAt ? `${form.startAt}:00` : undefined,
+      endAt: form.endAt ? `${form.endAt}:00` : undefined,
+    })
+  }
+
+  const handleCancel = async () => {
+    if (!window.confirm("이 펀딩 캠페인을 취소하시겠습니까?")) return
+    await cancelMutation.mutateAsync("seller-console")
+  }
+
+  if (detailQuery.isLoading || !form) {
+    return (
+      <div className="mx-auto flex min-h-[40vh] max-w-3xl items-center justify-center">
+        <div className="glass-panel rounded-[1.8rem] px-6 py-8 text-center text-sm text-muted-foreground">
+          펀딩 상세를 불러오는 중입니다.
+        </div>
+      </div>
+    )
+  }
+
+  if (!campaign) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <Alert variant="destructive">
+          <AlertDescription>펀딩 상세를 찾을 수 없습니다.</AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <PageIntro
+        eyebrow="Funding Detail"
+        title={campaign.title}
+        description="펀딩 상세와 수정 화면입니다. 기본 설정을 조정하고 진행 중인 캠페인은 여기서 취소할 수 있습니다."
+        meta={[campaign.status, campaign.fundingType, campaign.progressLabel]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Quick actions
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button asChild size="sm" variant="outline">
+              <Link to="/business/funding">목록으로</Link>
+            </Button>
+            {campaign.statusCode === "ACTIVE" ? (
+              <Button size="sm" variant="destructive" onClick={handleCancel} disabled={cancelMutation.isPending}>
+                <Ban size={14} />
+                캠페인 취소
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      </PageIntro>
+
+      {(updateMutation.error || cancelMutation.error) ? (
+        <Alert variant="destructive">
+          <AlertDescription>
+            {updateMutation.error?.message ?? cancelMutation.error?.message ?? "펀딩 처리에 실패했습니다."}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Card>
+        <CardContent className="p-6">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <Label>캠페인 제목</Label>
+              <Input value={form.title} onChange={(event) => handleChange("title", event.target.value)} />
+            </div>
+            <div>
+              <Label>메이커명</Label>
+              <Input value={form.makerName} onChange={(event) => handleChange("makerName", event.target.value)} />
+            </div>
+            <div>
+              <Label>카테고리</Label>
+              <Input value={form.category} onChange={(event) => handleChange("category", event.target.value)} />
+            </div>
+            <div>
+              <Label>목표 금액</Label>
+              <Input type="number" value={form.goalAmount} onChange={(event) => handleChange("goalAmount", event.target.value)} />
+            </div>
+            {campaign.fundingType === "QUANTITY_BASED" ? (
+              <div>
+                <Label>목표 수량</Label>
+                <Input type="number" value={form.goalQuantity} onChange={(event) => handleChange("goalQuantity", event.target.value)} />
+              </div>
+            ) : null}
+            <div>
+              <Label>최소 참여 금액</Label>
+              <Input type="number" value={form.minAmount} onChange={(event) => handleChange("minAmount", event.target.value)} />
+            </div>
+            <div>
+              <Label>시작 일시</Label>
+              <Input type="datetime-local" value={form.startAt} onChange={(event) => handleChange("startAt", event.target.value)} />
+            </div>
+            <div>
+              <Label>종료 일시</Label>
+              <Input type="datetime-local" value={form.endAt} onChange={(event) => handleChange("endAt", event.target.value)} />
+            </div>
+            <div className="sm:col-span-2">
+              <Label>요약</Label>
+              <Textarea rows={5} value={form.summary} onChange={(event) => handleChange("summary", event.target.value)} />
+            </div>
+          </div>
+
+          <div className="mt-6 flex justify-end">
+            <Button onClick={handleSubmit} disabled={updateMutation.isPending}>
+              <Save size={14} />
+              {updateMutation.isPending ? "저장 중..." : "변경 저장"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/domains/gateway/page/Gateway.jsx
+++ b/src/domains/gateway/page/Gateway.jsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from "@/components/ui/card.js";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert.js";
 import { Badge } from "@/components/ui/badge.js";
 import { Separator } from "@/components/ui/separator.js";
+import PageIntro from "@/components/layout/PageIntro.jsx";
 
 const STATUS_ITEMS = [
   { label: "API 연결",   status: "정상",   ok: true },
@@ -22,6 +23,7 @@ export default function GatewayPage() {
   const [selectedEvents, setSelectedEvents] = useState(["주문 생성", "결제 완료"]);
   const [copied, setCopied] = useState(false);
   const [saved, setSaved] = useState(false);
+  const healthyCount = STATUS_ITEMS.filter((item) => item.ok).length;
 
   const handleCopy = () => {
     navigator.clipboard.writeText(apiKey);
@@ -35,21 +37,39 @@ export default function GatewayPage() {
   const handleSave = () => { setSaved(true); setTimeout(() => setSaved(false), 2500); };
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold">게이트웨이</h1>
-        <p className="text-muted-foreground text-sm mt-1">API 연동 및 서비스 상태를 관리하세요.</p>
-      </div>
+    <div className="mx-auto max-w-6xl space-y-6">
+      <PageIntro
+        eyebrow="Integration Settings"
+        title="연동 설정"
+        description="외부 서비스 연동과 보안 키, 웹훅 이벤트를 운영자 시점에서 차분하게 다루도록 재정렬했습니다. 중요한 상태와 액션을 분리해 실수 확률을 낮추는 방향입니다."
+        meta={[
+          `정상 서비스 ${healthyCount}/${STATUS_ITEMS.length}`,
+          `이벤트 선택 ${selectedEvents.length}개`,
+          saved ? "설정 저장됨" : "설정 대기",
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Integration state
+          </p>
+          <p className="mt-3 text-lg font-semibold text-foreground">
+            보안 키와 웹훅 이벤트를 분리 관리
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            저장 전후 상태를 알림으로 분명하게 보여줍니다.
+          </p>
+        </div>
+      </PageIntro>
 
       {saved && (
-        <Alert className="mb-4">
+        <Alert>
           <AlertTitle>저장 완료</AlertTitle>
           <AlertDescription>설정이 저장되었습니다.</AlertDescription>
         </Alert>
       )}
 
-      {/* Service Status */}
-      <Card className="mb-4">
+      <div className="grid gap-4 lg:grid-cols-2">
+      <Card>
         <CardContent className="p-5">
           <h3 className="text-sm font-semibold mb-4 flex items-center gap-2">
             <Shield size={15} className="text-primary" />서비스 상태
@@ -69,8 +89,7 @@ export default function GatewayPage() {
         </CardContent>
       </Card>
 
-      {/* API Key */}
-      <Card className="mb-4">
+      <Card>
         <CardContent className="p-5">
           <h3 className="text-sm font-semibold mb-4 flex items-center gap-2">
             <Key size={15} className="text-primary" />API Key
@@ -90,8 +109,8 @@ export default function GatewayPage() {
           </p>
         </CardContent>
       </Card>
+      </div>
 
-      {/* Webhook */}
       <Card>
         <CardContent className="p-5 flex flex-col gap-4">
           <h3 className="text-sm font-semibold flex items-center gap-2">

--- a/src/domains/hotdeal/api/hotDealApi.js
+++ b/src/domains/hotdeal/api/hotDealApi.js
@@ -1,17 +1,47 @@
 import apiInstance from "@/common/api/apiInstance.js"
+import { normalizeApiError, unwrapApiResponseBody } from "@/common/api/responseUtils.js"
+import {
+  demoCreateHotDeal,
+  demoGetHotDealById,
+  demoGetHotDeals,
+  isDemoModeEnabled,
+} from "@/domains/management/mock/demoBackend.js"
 
 export async function createHotDeal(payload) {
-  console.log(payload)
-  const { data } = await apiInstance.post("/v1/hot-deals", payload)
-  return data
+  if (isDemoModeEnabled()) {
+    return demoCreateHotDeal(payload)
+  }
+
+  try {
+    const response = await apiInstance.post("/v1/hot-deals", payload)
+    return unwrapApiResponseBody(response, "핫딜 등록에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "핫딜 등록에 실패했습니다.")
+  }
 }
 
 export async function getHotDeals(params = {}) {
-  const { data } = await apiInstance.get("/v1/hot-deals", { params })
-  return data?.data ?? []
+  if (isDemoModeEnabled()) {
+    return demoGetHotDeals(params)
+  }
+
+  try {
+    const response = await apiInstance.get("/v1/hot-deals", { params })
+    return unwrapApiResponseBody(response, "핫딜 목록을 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "핫딜 목록 조회에 실패했습니다.")
+  }
 }
 
 export async function getHotDealById(hotDealId) {
-  const { data } = await apiInstance.get(`/v1/hot-deals/${hotDealId}`)
-  return data?.data ?? null
+  if (isDemoModeEnabled()) {
+    return demoGetHotDealById(hotDealId)
+  }
+
+  try {
+    const response = await apiInstance.get(`/v1/hot-deals/${hotDealId}`)
+    return unwrapApiResponseBody(response, "핫딜 정보를 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "핫딜 조회에 실패했습니다.")
+  }
 }

--- a/src/domains/hotdeal/hook/useHotDealQuery.js
+++ b/src/domains/hotdeal/hook/useHotDealQuery.js
@@ -1,17 +1,31 @@
 import { useQuery } from "@tanstack/react-query"
+import { shouldRetryRequest } from "@/common/api/queryRetry.js"
 import { getHotDeals, getHotDealById } from "../api/hotDealApi.js"
+import { mapHotDealListPayload, mapHotDealPayload } from "../lib/hotDealMappers.js"
+
+export const hotDealKeys = {
+  all: ["hot-deals"],
+  lists: () => [...hotDealKeys.all, "list"],
+  list: (params) => [...hotDealKeys.lists(), params],
+  details: () => [...hotDealKeys.all, "detail"],
+  detail: (hotDealId) => [...hotDealKeys.details(), hotDealId],
+}
 
 export function useHotDealsQuery(params = {}) {
   return useQuery({
-    queryKey: ["hot-deals", params],
-    queryFn: () => getHotDeals(params),
+    queryKey: hotDealKeys.list(params),
+    queryFn: async () => mapHotDealListPayload(await getHotDeals(params)),
+    retry: shouldRetryRequest,
+    staleTime: 30_000,
   })
 }
 
 export function useHotDealQuery(hotDealId) {
   return useQuery({
-    queryKey: ["hot-deals", hotDealId],
-    queryFn: () => getHotDealById(hotDealId),
+    queryKey: hotDealKeys.detail(hotDealId),
+    queryFn: async () => mapHotDealPayload(await getHotDealById(hotDealId)),
     enabled: !!hotDealId,
+    retry: shouldRetryRequest,
+    staleTime: 30_000,
   })
 }

--- a/src/domains/hotdeal/lib/hotDealMappers.js
+++ b/src/domains/hotdeal/lib/hotDealMappers.js
@@ -1,0 +1,98 @@
+const currencyFormatter = new Intl.NumberFormat("ko-KR")
+
+function toNumber(value, fallback = 0) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function toNullableNumber(value) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+function toText(value, fallback = "") {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim()
+  }
+
+  return fallback
+}
+
+function toId(value, fallback = null) {
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  const normalized = String(value).trim()
+  return normalized || fallback
+}
+
+function formatPrice(value) {
+  const number = toNullableNumber(value)
+
+  if (number === null) {
+    return value ? String(value) : "-"
+  }
+
+  return `${currencyFormatter.format(number)}원`
+}
+
+function mapHotDealStatus(status) {
+  switch (String(status || "").toUpperCase()) {
+    case "SCHEDULED":
+      return "오픈 예정"
+    case "ACTIVE":
+      return "진행 중"
+    case "ENDED":
+      return "종료"
+    case "CANCELLED":
+      return "취소됨"
+    default:
+      return status ? String(status) : "상태 미정"
+  }
+}
+
+function mapHotDeal(raw = {}) {
+  const soldQuantity = toNumber(raw?.soldQuantity, 0)
+  const maxQuantity = toNumber(raw?.maxQuantity, 0)
+  const progressRate = maxQuantity > 0 ? Math.min(100, Math.round((soldQuantity / maxQuantity) * 100)) : 0
+
+  return {
+    id: toId(raw?.hotDealId ?? raw?.id),
+    itemId: toId(raw?.itemId),
+    title: toText(raw?.title, "이름 없는 핫딜"),
+    statusCode: toText(raw?.status, "ACTIVE").toUpperCase(),
+    status: mapHotDealStatus(raw?.status),
+    discountRate: toNumber(raw?.discountRate, 0),
+    discountedPrice: toNullableNumber(raw?.discountedPrice),
+    discountedPriceText: formatPrice(raw?.discountedPrice),
+    originalPrice: toNullableNumber(raw?.originalPrice),
+    originalPriceText: formatPrice(raw?.originalPrice),
+    soldQuantity,
+    maxQuantity,
+    remainingQuantity: Math.max(maxQuantity - soldQuantity, 0),
+    progressRate,
+    endAt: raw?.endAt ?? null,
+    startAt: raw?.startAt ?? null,
+    maxPerUser: toNullableNumber(raw?.maxPerUser),
+  }
+}
+
+export function mapHotDealListPayload(payload) {
+  const items = Array.isArray(payload?.items) ? payload.items : Array.isArray(payload) ? payload : []
+
+  return {
+    items: items.map(mapHotDeal),
+    nextCursor: payload?.nextCursor ?? null,
+    hasNext: Boolean(payload?.hasNext ?? payload?.nextCursor),
+    totalCount: payload?.totalCount ?? items.length,
+  }
+}
+
+export function mapHotDealPayload(payload) {
+  if (!payload) {
+    return null
+  }
+
+  return mapHotDeal(payload)
+}

--- a/src/domains/hotdeal/page/HotDeal.jsx
+++ b/src/domains/hotdeal/page/HotDeal.jsx
@@ -1,11 +1,17 @@
 import { useState, useEffect, useActionState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
-import { Check } from "lucide-react"
+import { AlertCircle, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { createHotDealAction } from "../actions/createHotDealAction.js"
+import { hotDealKeys } from "../hook/useHotDealQuery.js"
 import { useSellerProductsQuery } from "@/domains/items/hook/useItemsQuery.js"
 import HotDealFormFields from "@/components/hotdeal/HotDealFormFields.jsx"
+import PageIntro from "@/components/layout/PageIntro.jsx"
+import { demoHotDealItems, demoItems } from "@/domains/management/mock/demoData.js"
+
+const numberFormatter = new Intl.NumberFormat("ko-KR")
 
 function HotDealForm({ onReset }) {
   const [itemId, setItemId] = useState("")
@@ -13,39 +19,148 @@ function HotDealForm({ onReset }) {
   const queryClient = useQueryClient()
 
   const [state, formAction, isPending] = useActionState(createHotDealAction, {})
-  const { data: products = [] } = useSellerProductsQuery()
-  console.log("products", products);
+  const { data: productsPayload } = useSellerProductsQuery()
+  const products = productsPayload?.items ?? []
+  const usingDemoHotDeals = import.meta.env.DEV && products.length === 0
+  const sourceProducts = usingDemoHotDeals ? demoItems : products
+  const hotDealItems = usingDemoHotDeals
+    ? demoHotDealItems
+    : sourceProducts.filter((product) => product?.status === "HOT_DEAL")
 
   useEffect(() => {
     if (state.success) {
-      queryClient.invalidateQueries({ queryKey: ["hot-deals"] })
+      queryClient.invalidateQueries({ queryKey: hotDealKeys.all })
     }
   }, [state.success, queryClient])
 
   if (state.success) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
-          <Check size={32} className="text-primary" />
+      <div className="mx-auto flex min-h-[60vh] max-w-xl items-center justify-center">
+        <div className="glass-panel surface-hero flex w-full flex-col items-center gap-4 rounded-[2rem] px-8 py-12 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/12">
+            <Check size={32} className="text-primary" />
+          </div>
+          <h2 className="display-title text-3xl font-semibold">핫딜 등록 완료!</h2>
+          <p className="max-w-md text-sm leading-6 text-muted-foreground">
+            핫딜이 성공적으로 등록되었습니다. 가격 자극과 수량 제약을 같은 화면에서 즉시 조절할 수 있습니다.
+          </p>
+          <Button onClick={onReset}>다시 등록하기</Button>
         </div>
-        <h2 className="text-xl font-bold">핫딜 등록 완료!</h2>
-        <p className="text-muted-foreground text-sm">핫딜이 성공적으로 등록되었습니다.</p>
-        <Button onClick={onReset}>다시 등록하기</Button>
       </div>
     )
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold">핫딜 설정</h1>
-        <p className="text-muted-foreground text-sm mt-1">한정 수량 특가 핫딜을 등록하세요.</p>
-      </div>
+    <div className="mx-auto max-w-6xl space-y-6">
+      <PageIntro
+        eyebrow="Hot Deal Management"
+        title="핫딜 관리"
+        description="한정 수량과 할인율을 중심으로 프로모션을 운영하는 화면입니다. 가격 임팩트가 바로 읽히도록 핵심 지점을 앞으로 끌어왔습니다."
+        meta={[
+          `할인율 ${discountRate}%`,
+          `연결 가능한 아이템 ${products.length}개`,
+          `${hotDealItems.length}개 핫딜 운영 중`,
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Promotion bias
+          </p>
+          <p className="mt-3 text-lg font-semibold text-foreground">
+            강한 가격 자극과 한정 수량
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            즉시성 있는 판매 이벤트에 맞춰 핵심 필드만 전면에 배치했습니다.
+          </p>
+        </div>
+      </PageIntro>
 
-      <Card className="bg-card border border-border rounded-xl overflow-hidden">
-        <div className="flex items-center gap-2 px-6 py-4 border-b border-border">
-          <div className="w-1 h-4 bg-primary rounded-full" />
-          <h3 className="font-semibold text-sm">핫딜 등록</h3>
+      <Card className="overflow-hidden">
+        <div className="border-b border-white/70 px-6 py-5 dark:border-slate-800">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="section-kicker">Current hot deals</p>
+              <h2 className="display-title mt-2 text-2xl text-foreground">진행 중인 핫딜</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                현재 내 상품 중 핫딜 상태인 항목을 먼저 확인하고, 필요할 때만 새 핫딜을 추가합니다.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {usingDemoHotDeals ? <Badge variant="outline">데모 데이터</Badge> : null}
+              <Badge variant="outline">{hotDealItems.length}개 진행 중</Badge>
+            </div>
+          </div>
+        </div>
+
+        <CardContent className="p-6">
+          {hotDealItems.length > 0 ? (
+            <div className="grid gap-4 lg:grid-cols-2">
+              {hotDealItems.map((item) => {
+                return (
+                  <div key={item.id} className="metric-chip rounded-[1.6rem] px-5 py-5">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-base font-semibold text-foreground">
+                          {item.title ?? `상품 #${item.id}`}
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          <Badge variant="default">활성</Badge>
+                          <Badge variant="outline">HOT_DEAL</Badge>
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-[0.72rem] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                          Price
+                        </p>
+                        <p className="mt-1 text-sm font-semibold text-primary">
+                          {item?.price ? `${numberFormatter.format(item.price)}원` : "-"}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                      <div>
+                        <p className="text-[0.72rem] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                          유형
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {item?.itemType === "PERFORMANCE" ? "공연" : "굿즈"}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-[0.72rem] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                          리뷰
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          평점 {item?.averageRating ?? 0} / {item?.reviewCount ?? 0}개
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="rounded-[1.8rem] border border-dashed border-border px-6 py-10 text-center">
+              <AlertCircle size={24} className="mx-auto text-primary/70" />
+              <h3 className="mt-4 text-lg font-semibold text-foreground">
+                현재 진행 중인 핫딜이 없습니다
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                아래 폼에서 새 핫딜을 추가할 수 있습니다.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="overflow-hidden">
+        <div className="border-b border-white/70 px-6 py-5 dark:border-slate-800">
+          <p className="section-kicker">Create hot deal</p>
+          <h2 className="display-title mt-2 text-2xl text-foreground">새 핫딜 등록</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            현재 목록과 별도로 새로운 한정 특가 이벤트를 추가할 때 사용합니다.
+          </p>
         </div>
 
         <div className="px-6 py-6">
@@ -57,7 +172,7 @@ function HotDealForm({ onReset }) {
             setItemId={setItemId}
             discountRate={discountRate}
             setDiscountRate={setDiscountRate}
-            products={products}
+            products={sourceProducts}
           />
         </div>
       </Card>

--- a/src/domains/hotdeal/page/HotDeal.jsx
+++ b/src/domains/hotdeal/page/HotDeal.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useActionState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { AlertCircle, Check } from "lucide-react"
+import { Link } from "react-router"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -135,6 +136,16 @@ function HotDealForm({ onReset }) {
                           평점 {item?.averageRating ?? 0} / {item?.reviewCount ?? 0}개
                         </p>
                       </div>
+                    </div>
+                    <div className="mt-5 flex flex-wrap gap-2">
+                      <Button asChild size="sm" variant="outline">
+                        <Link
+                          to={`/business/hotdeal/${item.hotDealId ?? item.id}`}
+                          state={{ hotDeal: item, hotDealId: item.hotDealId ?? item.id }}
+                        >
+                          상세 보기
+                        </Link>
+                      </Button>
                     </div>
                   </div>
                 )

--- a/src/domains/hotdeal/page/HotDealDetail.jsx
+++ b/src/domains/hotdeal/page/HotDealDetail.jsx
@@ -1,0 +1,121 @@
+import { Link, useLocation, useParams } from "react-router"
+import { Clock3, Percent, TicketPercent } from "lucide-react"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import PageIntro from "@/components/layout/PageIntro.jsx"
+import { useHotDealQuery } from "@/domains/hotdeal/hook/useHotDealQuery.js"
+
+function formatDateTime(value) {
+  if (!value) return "-"
+  return String(value).replace("T", " ").slice(0, 16)
+}
+
+export default function HotDealDetailPage() {
+  const { hotDealId } = useParams()
+  const location = useLocation()
+  const hotDealFromState = location.state?.hotDeal ?? null
+  const detailQuery = useHotDealQuery(location.state?.hotDealId ?? hotDealId)
+  const hotDeal = detailQuery.data ?? hotDealFromState
+
+  if (detailQuery.isLoading && !hotDeal) {
+    return (
+      <div className="mx-auto flex min-h-[40vh] max-w-3xl items-center justify-center">
+        <div className="glass-panel rounded-[1.8rem] px-6 py-8 text-center text-sm text-muted-foreground">
+          핫딜 상세를 불러오는 중입니다.
+        </div>
+      </div>
+    )
+  }
+
+  if (!hotDeal) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <Alert variant="destructive">
+          <AlertDescription>
+            핫딜 상세를 찾을 수 없습니다. 현재 백엔드에는 seller 전용 핫딜 수정 API가 없어, 목록에서 전달된 정보 기준으로만 상세를 보여줄 수 있습니다.
+          </AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <PageIntro
+        eyebrow="Hot Deal Detail"
+        title={hotDeal.title ?? "핫딜 상세"}
+        description="핫딜 상세 확인 화면입니다. 현재 백엔드에는 seller 전용 수정/삭제 API가 확인되지 않아 읽기 중심으로 구성했습니다."
+        meta={[
+          hotDeal.status ?? "상태 미정",
+          hotDeal.discountRate != null ? `${hotDeal.discountRate}% 할인` : "할인율 없음",
+          hotDeal.discountedPriceText ?? "-",
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Quick actions
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button asChild size="sm" variant="outline">
+              <Link to="/business/hotdeal">목록으로</Link>
+            </Button>
+          </div>
+        </div>
+      </PageIntro>
+
+      <Card>
+        <CardContent className="p-6">
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="metric-chip rounded-[1.5rem] px-4 py-4">
+              <div className="flex items-center gap-2">
+                <Percent size={16} className="text-primary" />
+                <p className="text-sm font-semibold text-foreground">할인율</p>
+              </div>
+              <p className="mt-3 text-lg font-semibold text-foreground">
+                {hotDeal.discountRate != null ? `${hotDeal.discountRate}%` : "-"}
+              </p>
+            </div>
+            <div className="metric-chip rounded-[1.5rem] px-4 py-4">
+              <div className="flex items-center gap-2">
+                <TicketPercent size={16} className="text-primary" />
+                <p className="text-sm font-semibold text-foreground">할인가</p>
+              </div>
+              <p className="mt-3 text-lg font-semibold text-foreground">
+                {hotDeal.discountedPriceText ?? hotDeal.price ? `${hotDeal.price}원` : "-"}
+              </p>
+            </div>
+            <div className="metric-chip rounded-[1.5rem] px-4 py-4">
+              <div className="flex items-center gap-2">
+                <Clock3 size={16} className="text-primary" />
+                <p className="text-sm font-semibold text-foreground">종료 시각</p>
+              </div>
+              <p className="mt-3 text-sm font-semibold text-foreground">
+                {formatDateTime(hotDeal.endAt)}
+              </p>
+            </div>
+            <div className="metric-chip rounded-[1.5rem] px-4 py-4">
+              <div className="flex items-center gap-2">
+                <Badge variant="outline">{hotDeal.status ?? "상태 미정"}</Badge>
+              </div>
+              <p className="mt-3 text-sm font-semibold text-foreground">
+                진행률 {hotDeal.progressRate ?? 0}%
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                판매 {hotDeal.soldQuantity ?? 0} / {hotDeal.maxQuantity ?? 0}
+              </p>
+            </div>
+          </div>
+
+          <Alert className="mt-6">
+            <AlertDescription>
+              seller 전용 핫딜 수정/삭제 API가 확인되지 않아 현재는 상세 확인만 제공합니다. 생성은 목록 화면에서 계속 할 수 있습니다.
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/domains/items/api/itemsApi.js
+++ b/src/domains/items/api/itemsApi.js
@@ -1,40 +1,105 @@
 import apiInstance from "@/common/api/apiInstance.js"
+import { normalizeApiError, unwrapApiResponseBody } from "@/common/api/responseUtils.js"
+import {
+  demoCreateGoods,
+  demoCreatePerformance,
+  demoDeleteProduct,
+  demoGetCategories,
+  demoGetMyStore,
+  demoGetSellerProducts,
+  demoToggleProductStatus,
+  isDemoModeEnabled,
+} from "@/domains/management/mock/demoBackend.js"
 
-export async function  getSellerProducts() {
-  const { data } = await apiInstance.get("/products");
-  console.log(data);
-  return data?.data;
+export async function getSellerProducts() {
+  if (isDemoModeEnabled()) {
+    return demoGetSellerProducts()
+  }
+
+  try {
+    const response = await apiInstance.get("/products")
+    return unwrapApiResponseBody(response, "상품 목록을 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "상품 목록 조회에 실패했습니다.")
+  }
 }
 
 export async function getCategories() {
-  const { data } = await apiInstance.get("/categories/tree")
-  return data?.data || []
+  if (isDemoModeEnabled()) {
+    return demoGetCategories()
+  }
+
+  try {
+    const response = await apiInstance.get("/categories/tree")
+    return unwrapApiResponseBody(response, "카테고리 목록을 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "카테고리 조회에 실패했습니다.")
+  }
 }
 
 
 export async function getMyStore() {
-  const { data } = await apiInstance.get("/store")
-  return data?.data?.[0] ?? null
+  if (isDemoModeEnabled()) {
+    return demoGetMyStore()
+  }
+
+  try {
+    const response = await apiInstance.get("/store")
+    const payload = unwrapApiResponseBody(response, "내 스토어 정보를 불러오지 못했습니다.")
+    return Array.isArray(payload) ? payload[0] ?? null : payload ?? null
+  } catch (error) {
+    throw normalizeApiError(error, "내 스토어 조회에 실패했습니다.")
+  }
 }
 
 export async function createGoods(payload) {
-  console.log(payload)
-  const { data } = await apiInstance.post("/goods", payload)
-  return data
+  if (isDemoModeEnabled()) {
+    return demoCreateGoods(payload)
+  }
+
+  try {
+    const response = await apiInstance.post("/goods", payload)
+    return unwrapApiResponseBody(response, "굿즈 등록에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "굿즈 등록에 실패했습니다.")
+  }
 }
 
 export async function createPerformance(payload) {
-  console.log("payload : ",payload);
-  const { data } = await apiInstance.post("/performances", payload)
-  return data
+  if (isDemoModeEnabled()) {
+    return demoCreatePerformance(payload)
+  }
+
+  try {
+    const response = await apiInstance.post("/performances", payload)
+    return unwrapApiResponseBody(response, "공연 등록에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "공연 등록에 실패했습니다.")
+  }
 }
 
 export async function toggleProductStatus(itemId, status) {
-  const { data } = await apiInstance.patch(`/items/${itemId}/status`, { status })
-  return data
+  if (isDemoModeEnabled()) {
+    return demoToggleProductStatus(itemId, status)
+  }
+
+  try {
+    const response = await apiInstance.patch(`/items/${itemId}/status`, { status })
+    return unwrapApiResponseBody(response, "상품 상태 변경에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "상품 상태 변경에 실패했습니다.")
+  }
 }
 
 export async function deleteProduct(itemId) {
-  const { data } = await apiInstance.delete(`/products/${itemId}`)
-  return data
+  if (isDemoModeEnabled()) {
+    return demoDeleteProduct(itemId)
+  }
+
+  try {
+    const response = await apiInstance.delete(`/products/${itemId}`)
+    return unwrapApiResponseBody(response, "상품 삭제에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "상품 삭제에 실패했습니다.")
+  }
 }

--- a/src/domains/items/api/itemsApi.js
+++ b/src/domains/items/api/itemsApi.js
@@ -6,8 +6,12 @@ import {
   demoDeleteProduct,
   demoGetCategories,
   demoGetMyStore,
+  demoGetSellerGoodsDetail,
+  demoGetSellerPerformanceDetail,
   demoGetSellerProducts,
   demoToggleProductStatus,
+  demoUpdateGoods,
+  demoUpdatePerformance,
   isDemoModeEnabled,
 } from "@/domains/management/mock/demoBackend.js"
 
@@ -101,5 +105,57 @@ export async function deleteProduct(itemId) {
     return unwrapApiResponseBody(response, "상품 삭제에 실패했습니다.")
   } catch (error) {
     throw normalizeApiError(error, "상품 삭제에 실패했습니다.")
+  }
+}
+
+export async function getSellerGoodsDetail(itemId) {
+  if (isDemoModeEnabled()) {
+    return demoGetSellerGoodsDetail(itemId)
+  }
+
+  try {
+    const response = await apiInstance.get(`/seller/goods/${itemId}`)
+    return unwrapApiResponseBody(response, "굿즈 상세를 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "굿즈 상세 조회에 실패했습니다.")
+  }
+}
+
+export async function getSellerPerformanceDetail(itemId) {
+  if (isDemoModeEnabled()) {
+    return demoGetSellerPerformanceDetail(itemId)
+  }
+
+  try {
+    const response = await apiInstance.get(`/seller/performances/${itemId}`)
+    return unwrapApiResponseBody(response, "공연 상세를 불러오지 못했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "공연 상세 조회에 실패했습니다.")
+  }
+}
+
+export async function updateGoods(itemId, payload) {
+  if (isDemoModeEnabled()) {
+    return demoUpdateGoods(itemId, payload)
+  }
+
+  try {
+    const response = await apiInstance.put(`/goods/${itemId}`, payload)
+    return unwrapApiResponseBody(response, "굿즈 수정에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "굿즈 수정에 실패했습니다.")
+  }
+}
+
+export async function updatePerformance(itemId, payload) {
+  if (isDemoModeEnabled()) {
+    return demoUpdatePerformance(itemId, payload)
+  }
+
+  try {
+    const response = await apiInstance.put(`/performances/${itemId}`, payload)
+    return unwrapApiResponseBody(response, "공연 수정에 실패했습니다.")
+  } catch (error) {
+    throw normalizeApiError(error, "공연 수정에 실패했습니다.")
   }
 }

--- a/src/domains/items/hook/useItemDetailMutations.js
+++ b/src/domains/items/hook/useItemDetailMutations.js
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { updateGoods, updatePerformance } from "@/domains/items/api/itemsApi.js"
+import { itemKeys } from "@/domains/items/hook/useItemsQuery.js"
+
+export function useUpdateGoodsMutation(itemId) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (payload) => updateGoods(itemId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: itemKeys.products() })
+      queryClient.invalidateQueries({ queryKey: itemKeys.detail("GOODS", itemId) })
+    },
+  })
+}
+
+export function useUpdatePerformanceMutation(itemId) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (payload) => updatePerformance(itemId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: itemKeys.products() })
+      queryClient.invalidateQueries({ queryKey: itemKeys.detail("PERFORMANCE", itemId) })
+    },
+  })
+}

--- a/src/domains/items/hook/useItemMutations.js
+++ b/src/domains/items/hook/useItemMutations.js
@@ -1,12 +1,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { toggleProductStatus, deleteProduct } from "../api/itemsApi.js"
+import { itemKeys } from "./useItemsQuery.js"
 
 export function useToggleStatusMutation() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: ({ itemId, status }) => toggleProductStatus(itemId, status),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["seller-products"] })
+      queryClient.invalidateQueries({ queryKey: itemKeys.products() })
     },
   })
 }
@@ -16,7 +17,7 @@ export function useDeleteItemMutation() {
   return useMutation({
     mutationFn: (itemId) => deleteProduct(itemId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["seller-products"] })
+      queryClient.invalidateQueries({ queryKey: itemKeys.products() })
     },
   })
 }

--- a/src/domains/items/hook/useItemsQuery.js
+++ b/src/domains/items/hook/useItemsQuery.js
@@ -1,9 +1,17 @@
 import { useQuery } from "@tanstack/react-query"
 import { shouldRetryRequest } from "@/common/api/queryRetry.js"
-import { getSellerProducts, getCategories, getMyStore } from "../api/itemsApi.js"
+import {
+  getSellerGoodsDetail,
+  getSellerPerformanceDetail,
+  getSellerProducts,
+  getCategories,
+  getMyStore,
+} from "../api/itemsApi.js"
 import {
   mapCategoryTreePayload,
   mapMyStorePayload,
+  mapSellerGoodsDetailPayload,
+  mapSellerPerformanceDetailPayload,
   mapSellerProductListPayload,
 } from "../lib/itemMappers.js"
 
@@ -12,6 +20,7 @@ export const itemKeys = {
   products: () => [...itemKeys.all, "seller-products"],
   categories: () => [...itemKeys.all, "categories"],
   store: () => ["store", "me"],
+  detail: (itemType, itemId) => [...itemKeys.all, "detail", itemType, itemId],
 }
 
 export function useSellerProductsQuery() {
@@ -36,6 +45,21 @@ export function useMyStoreQuery() {
   return useQuery({
     queryKey: itemKeys.store(),
     queryFn: async () => mapMyStorePayload(await getMyStore()),
+    retry: shouldRetryRequest,
+    staleTime: 30_000,
+  })
+}
+
+export function useSellerItemDetailQuery(itemId, itemType) {
+  return useQuery({
+    queryKey: itemKeys.detail(itemType, itemId),
+    queryFn: async () => {
+      if (String(itemType).toUpperCase() === "PERFORMANCE") {
+        return mapSellerPerformanceDetailPayload(await getSellerPerformanceDetail(itemId))
+      }
+      return mapSellerGoodsDetailPayload(await getSellerGoodsDetail(itemId))
+    },
+    enabled: Boolean(itemId && itemType),
     retry: shouldRetryRequest,
     staleTime: 30_000,
   })

--- a/src/domains/items/hook/useItemsQuery.js
+++ b/src/domains/items/hook/useItemsQuery.js
@@ -1,24 +1,42 @@
 import { useQuery } from "@tanstack/react-query"
+import { shouldRetryRequest } from "@/common/api/queryRetry.js"
 import { getSellerProducts, getCategories, getMyStore } from "../api/itemsApi.js"
+import {
+  mapCategoryTreePayload,
+  mapMyStorePayload,
+  mapSellerProductListPayload,
+} from "../lib/itemMappers.js"
+
+export const itemKeys = {
+  all: ["items"],
+  products: () => [...itemKeys.all, "seller-products"],
+  categories: () => [...itemKeys.all, "categories"],
+  store: () => ["store", "me"],
+}
 
 export function useSellerProductsQuery() {
   return useQuery({
-    queryKey: ["seller-products"],
-    queryFn: getSellerProducts,
-    select: (data) => data?.items ?? [],
+    queryKey: itemKeys.products(),
+    queryFn: async () => mapSellerProductListPayload(await getSellerProducts()),
+    retry: shouldRetryRequest,
+    staleTime: 30_000,
   })
 }
 
 export function useCategoriesQuery() {
   return useQuery({
-    queryKey: ["categories"],
-    queryFn: getCategories,
+    queryKey: itemKeys.categories(),
+    queryFn: async () => mapCategoryTreePayload(await getCategories()),
+    retry: shouldRetryRequest,
+    staleTime: 30_000,
   })
 }
 
 export function useMyStoreQuery() {
   return useQuery({
-    queryKey: ["store", "me"],
-    queryFn: getMyStore,
+    queryKey: itemKeys.store(),
+    queryFn: async () => mapMyStorePayload(await getMyStore()),
+    retry: shouldRetryRequest,
+    staleTime: 30_000,
   })
 }

--- a/src/domains/items/lib/itemMappers.js
+++ b/src/domains/items/lib/itemMappers.js
@@ -1,0 +1,103 @@
+const currencyFormatter = new Intl.NumberFormat("ko-KR")
+
+function toNumber(value, fallback = 0) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function toNullableNumber(value) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+function toText(value, fallback = "") {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim()
+  }
+
+  return fallback
+}
+
+function toId(value, fallback = null) {
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  const normalized = String(value).trim()
+  return normalized || fallback
+}
+
+export function formatPrice(value) {
+  const number = toNullableNumber(value)
+
+  if (number === null) {
+    return value ? String(value) : "-"
+  }
+
+  return `${currencyFormatter.format(number)}원`
+}
+
+export function mapSellerProductSummary(raw = {}) {
+  const itemType = toText(raw?.itemType ?? raw?.type, "GOODS").toUpperCase()
+  const status = toText(raw?.status, "DRAFT").toUpperCase()
+
+  return {
+    id: toId(raw?.itemId ?? raw?.id),
+    sellerId: toId(raw?.sellerId),
+    storeId: toId(raw?.storeId),
+    title: toText(raw?.title ?? raw?.name, "상품 정보 준비 중"),
+    price: toNullableNumber(raw?.price),
+    priceText: formatPrice(raw?.price),
+    itemType,
+    status,
+    averageRating: toNullableNumber(raw?.averageRating) ?? 0,
+    reviewCount: toNumber(raw?.reviewCount, 0),
+    thumbnailMediaId: toId(raw?.thumbnailMediaId),
+    thumbnailUrl: toText(raw?.thumbnailUrl),
+  }
+}
+
+export function mapSellerProductListPayload(payload) {
+  const items = Array.isArray(payload?.items) ? payload.items : Array.isArray(payload) ? payload : []
+
+  return {
+    items: items.map(mapSellerProductSummary),
+    nextCursor: payload?.nextCursor ?? null,
+    hasNext: Boolean(payload?.hasNext ?? payload?.nextCursor),
+    totalCount: payload?.totalCount ?? items.length,
+  }
+}
+
+function mapCategoryNode(node = {}) {
+  return {
+    id: toId(node?.id),
+    name: toText(node?.name, "이름 없음"),
+    children: Array.isArray(node?.children) ? node.children.map(mapCategoryNode) : [],
+  }
+}
+
+export function mapCategoryTreePayload(payload) {
+  const items = Array.isArray(payload?.items) ? payload.items : Array.isArray(payload) ? payload : []
+  return items.map(mapCategoryNode)
+}
+
+export function mapMyStorePayload(raw) {
+  if (!raw) {
+    return null
+  }
+
+  const storeName = toText(raw?.storeName ?? raw?.store_name ?? raw?.name, "내 스토어")
+
+  return {
+    ...raw,
+    id: toId(raw?.storeId ?? raw?.id),
+    userId: toId(raw?.userId),
+    storeName,
+    store_name: storeName,
+    name: storeName,
+    status: toText(raw?.status, "INACTIVE"),
+    description: toText(raw?.description),
+    addresses: Array.isArray(raw?.addresses) ? raw.addresses : [],
+    contacts: Array.isArray(raw?.contacts) ? raw.contacts : [],
+  }
+}

--- a/src/domains/items/lib/itemMappers.js
+++ b/src/domains/items/lib/itemMappers.js
@@ -101,3 +101,72 @@ export function mapMyStorePayload(raw) {
     contacts: Array.isArray(raw?.contacts) ? raw.contacts : [],
   }
 }
+
+function mapItemOption(option = {}) {
+  return {
+    id: toId(option?.id),
+    optionName: toText(option?.optionName, "기본"),
+    additionalPrice: toNullableNumber(option?.additionalPrice) ?? 0,
+    stockQuantity: toNumber(option?.stockQuantity, 0),
+  }
+}
+
+function mapShippingInfo(info = {}) {
+  return {
+    shippingFee: toNullableNumber(info?.shippingFee) ?? 0,
+    estimatedDays: toNumber(info?.estimatedDays, 3),
+    freeShippingThreshold: toNullableNumber(info?.freeShippingThreshold),
+    returnPolicy: toText(info?.returnPolicy),
+    carrier: toText(info?.carrier),
+    shipFrom: toText(info?.shipFrom),
+    returnAddress: toText(info?.returnAddress),
+    returnShippingFee: toNullableNumber(info?.returnShippingFee),
+    exchangeShippingFee: toNullableNumber(info?.exchangeShippingFee),
+    shippingNotice: toText(info?.shippingNotice),
+  }
+}
+
+function mapSeatGrade(grade = {}) {
+  return {
+    id: toId(grade?.id),
+    gradeName: toText(grade?.gradeName, "일반"),
+    price: toNullableNumber(grade?.price) ?? 0,
+    totalQuantity: toNumber(grade?.totalQuantity, 0),
+    fundingQuantity: toNumber(grade?.fundingQuantity, 0),
+  }
+}
+
+export function mapSellerGoodsDetailPayload(raw) {
+  if (!raw) return null
+
+  return {
+    ...mapSellerProductSummary(raw),
+    description: toText(raw?.description),
+    categoryId: toId(raw?.categoryId),
+    categoryName: toText(raw?.categoryName),
+    options: Array.isArray(raw?.options) ? raw.options.map(mapItemOption) : [],
+    shippingInfo: mapShippingInfo(raw?.shippingInfo ?? {}),
+  }
+}
+
+export function mapSellerPerformanceDetailPayload(raw) {
+  if (!raw) return null
+
+  return {
+    ...mapSellerProductSummary(raw),
+    description: toText(raw?.description),
+    categoryId: toId(raw?.categoryId),
+    categoryName: toText(raw?.categoryName),
+    venue: toText(raw?.venue),
+    performanceDate: raw?.performanceDate ?? "",
+    performanceTime: raw?.performanceTime ?? "",
+    totalSeats: toNumber(raw?.totalSeats, 0),
+    runningTimeMinutes: toNullableNumber(raw?.runningTimeMinutes),
+    ageLimit: toText(raw?.ageLimit),
+    venueAddress: toText(raw?.venueAddress),
+    bookingNotice: toText(raw?.bookingNotice),
+    organizer: toText(raw?.organizer),
+    host: toText(raw?.host),
+    seatGrades: Array.isArray(raw?.seatGrades) ? raw.seatGrades.map(mapSeatGrade) : [],
+  }
+}

--- a/src/domains/items/page/ItemDetail.jsx
+++ b/src/domains/items/page/ItemDetail.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { Link, useLocation, useParams } from "react-router"
 import { Save, Store, Ticket } from "lucide-react"
 
@@ -10,7 +10,6 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import {
-  itemKeys,
   useSellerItemDetailQuery,
   useSellerProductsQuery,
 } from "@/domains/items/hook/useItemsQuery.js"
@@ -35,72 +34,46 @@ function getRouteItemType(locationState, itemSummary) {
   return ""
 }
 
-export default function ItemDetailPage() {
-  const { itemId } = useParams()
-  const location = useLocation()
-  const { data: productsPayload } = useSellerProductsQuery()
-  const { data: categoryTree = [] } = useCategoriesQuery()
-  const products = productsPayload?.items ?? []
-  const itemSummary = products.find((item) => String(item.id) === String(itemId)) ?? null
-  const itemType = getRouteItemType(location.state, itemSummary)
-  const detailQuery = useSellerItemDetailQuery(itemId, itemType)
-  const item = detailQuery.data
-
-  const goodsCategories = useMemo(
-    () =>
-      categoryTree
-        .filter((category) => category.name !== "공연/티켓")
-        .flatMap((category) => flattenTree(category)),
-    [categoryTree]
-  )
-  const performanceCategories = useMemo(() => {
-    const perfNode = categoryTree.find((category) => category.name === "공연/티켓")
-    return perfNode ? flattenTree(perfNode) : []
-  }, [categoryTree])
-
-  const [form, setForm] = useState(null)
-
-  useEffect(() => {
-    if (!item) return
-
-    if (item.itemType === "PERFORMANCE") {
-      const firstSeatGrade = item.seatGrades?.[0] ?? {}
-      setForm({
-        title: item.title ?? "",
-        categoryId: String(item.categoryId ?? ""),
-        price: String(item.price ?? 0),
-        description: item.description ?? "",
-        venue: item.venue ?? "",
-        performanceDate: item.performanceDate ?? "",
-        performanceTime: String(item.performanceTime ?? "").slice(0, 5),
-        totalSeats: String(item.totalSeats ?? 0),
-        runningTimeMinutes: item.runningTimeMinutes ? String(item.runningTimeMinutes) : "",
-        ageLimit: item.ageLimit ?? "",
-        venueAddress: item.venueAddress ?? "",
-        bookingNotice: item.bookingNotice ?? "",
-        organizer: item.organizer ?? "",
-        host: item.host ?? "",
-        gradeName: firstSeatGrade.gradeName ?? "일반",
-        gradePrice: String(firstSeatGrade.price ?? item.price ?? 0),
-      })
-      return
-    }
-
-    const firstOption = item?.options?.[0] ?? {}
-    const shippingInfo = item?.shippingInfo ?? {}
-    setForm({
+function buildItemForm(item) {
+  if (item.itemType === "PERFORMANCE") {
+    const firstSeatGrade = item.seatGrades?.[0] ?? {}
+    return {
       title: item.title ?? "",
       categoryId: String(item.categoryId ?? ""),
       price: String(item.price ?? 0),
       description: item.description ?? "",
-      optionName: firstOption.optionName ?? "기본",
-      additionalPrice: String(firstOption.additionalPrice ?? 0),
-      stockQuantity: String(firstOption.stockQuantity ?? 0),
-      shippingFee: String(shippingInfo.shippingFee ?? 0),
-      estimatedDays: String(shippingInfo.estimatedDays ?? 3),
-    })
-  }, [item])
+      venue: item.venue ?? "",
+      performanceDate: item.performanceDate ?? "",
+      performanceTime: String(item.performanceTime ?? "").slice(0, 5),
+      totalSeats: String(item.totalSeats ?? 0),
+      runningTimeMinutes: item.runningTimeMinutes ? String(item.runningTimeMinutes) : "",
+      ageLimit: item.ageLimit ?? "",
+      venueAddress: item.venueAddress ?? "",
+      bookingNotice: item.bookingNotice ?? "",
+      organizer: item.organizer ?? "",
+      host: item.host ?? "",
+      gradeName: firstSeatGrade.gradeName ?? "일반",
+      gradePrice: String(firstSeatGrade.price ?? item.price ?? 0),
+    }
+  }
 
+  const firstOption = item?.options?.[0] ?? {}
+  const shippingInfo = item?.shippingInfo ?? {}
+  return {
+    title: item.title ?? "",
+    categoryId: String(item.categoryId ?? ""),
+    price: String(item.price ?? 0),
+    description: item.description ?? "",
+    optionName: firstOption.optionName ?? "기본",
+    additionalPrice: String(firstOption.additionalPrice ?? 0),
+    stockQuantity: String(firstOption.stockQuantity ?? 0),
+    shippingFee: String(shippingInfo.shippingFee ?? 0),
+    estimatedDays: String(shippingInfo.estimatedDays ?? 3),
+  }
+}
+
+function ItemDetailEditor({ item, categories, itemId }) {
+  const [form, setForm] = useState(() => buildItemForm(item))
   const updateGoodsMutation = useUpdateGoodsMutation(itemId)
   const updatePerformanceMutation = useUpdatePerformanceMutation(itemId)
 
@@ -161,52 +134,8 @@ export default function ItemDetailPage() {
   const saveBusy = updateGoodsMutation.isPending || updatePerformanceMutation.isPending
   const saveError = updateGoodsMutation.error || updatePerformanceMutation.error
 
-  if (detailQuery.isLoading || !form) {
-    return (
-      <div className="mx-auto flex min-h-[40vh] max-w-3xl items-center justify-center">
-        <div className="glass-panel rounded-[1.8rem] px-6 py-8 text-center text-sm text-muted-foreground">
-          상품 상세를 불러오는 중입니다.
-        </div>
-      </div>
-    )
-  }
-
-  if (!item) {
-    return (
-      <div className="mx-auto max-w-3xl">
-        <Alert variant="destructive">
-          <AlertDescription>상품 상세를 찾을 수 없습니다.</AlertDescription>
-        </Alert>
-      </div>
-    )
-  }
-
-  const categories = item.itemType === "PERFORMANCE" ? performanceCategories : goodsCategories
-
   return (
-    <div className="mx-auto max-w-5xl space-y-6">
-      <PageIntro
-        eyebrow="Item Detail"
-        title={item.title}
-        description="상품 상세와 수정 화면입니다. 관리 목록에서 들어온 뒤 필요한 필드만 바로 수정할 수 있습니다."
-        meta={[
-          item.itemType === "PERFORMANCE" ? "공연" : "굿즈",
-          item.status ?? "상태 미정",
-          item.priceText ?? "-",
-        ]}
-      >
-        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
-          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
-            Quick actions
-          </p>
-          <div className="mt-3 flex flex-wrap gap-2">
-            <Button asChild size="sm" variant="outline">
-              <Link to="/business/items">목록으로</Link>
-            </Button>
-          </div>
-        </div>
-      </PageIntro>
-
+    <>
       {saveError ? (
         <Alert variant="destructive">
           <AlertDescription>
@@ -346,6 +275,84 @@ export default function ItemDetailPage() {
           </div>
         </CardContent>
       </Card>
+    </>
+  )
+}
+
+export default function ItemDetailPage() {
+  const { itemId } = useParams()
+  const location = useLocation()
+  const { data: productsPayload } = useSellerProductsQuery()
+  const { data: categoryTree = [] } = useCategoriesQuery()
+  const products = productsPayload?.items ?? []
+  const itemSummary = products.find((item) => String(item.id) === String(itemId)) ?? null
+  const itemType = getRouteItemType(location.state, itemSummary)
+  const detailQuery = useSellerItemDetailQuery(itemId, itemType)
+  const item = detailQuery.data
+
+  const goodsCategories = useMemo(
+    () =>
+      categoryTree
+        .filter((category) => category.name !== "공연/티켓")
+        .flatMap((category) => flattenTree(category)),
+    [categoryTree]
+  )
+  const performanceCategories = useMemo(() => {
+    const perfNode = categoryTree.find((category) => category.name === "공연/티켓")
+    return perfNode ? flattenTree(perfNode) : []
+  }, [categoryTree])
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="mx-auto flex min-h-[40vh] max-w-3xl items-center justify-center">
+        <div className="glass-panel rounded-[1.8rem] px-6 py-8 text-center text-sm text-muted-foreground">
+          상품 상세를 불러오는 중입니다.
+        </div>
+      </div>
+    )
+  }
+
+  if (!item) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <Alert variant="destructive">
+          <AlertDescription>상품 상세를 찾을 수 없습니다.</AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  const categories = item.itemType === "PERFORMANCE" ? performanceCategories : goodsCategories
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <PageIntro
+        eyebrow="Item Detail"
+        title={item.title}
+        description="상품 상세와 수정 화면입니다. 관리 목록에서 들어온 뒤 필요한 필드만 바로 수정할 수 있습니다."
+        meta={[
+          item.itemType === "PERFORMANCE" ? "공연" : "굿즈",
+          item.status ?? "상태 미정",
+          item.priceText ?? "-",
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Quick actions
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button asChild size="sm" variant="outline">
+              <Link to="/business/items">목록으로</Link>
+            </Button>
+          </div>
+        </div>
+      </PageIntro>
+      <ItemDetailEditor
+        key={`${item.id}-${item.updatedAt ?? ""}`}
+        item={item}
+        categories={categories}
+        itemId={itemId}
+      />
     </div>
   )
 }

--- a/src/domains/items/page/ItemDetail.jsx
+++ b/src/domains/items/page/ItemDetail.jsx
@@ -1,0 +1,351 @@
+import { useEffect, useMemo, useState } from "react"
+import { Link, useLocation, useParams } from "react-router"
+import { Save, Store, Ticket } from "lucide-react"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  itemKeys,
+  useSellerItemDetailQuery,
+  useSellerProductsQuery,
+} from "@/domains/items/hook/useItemsQuery.js"
+import {
+  useUpdateGoodsMutation,
+  useUpdatePerformanceMutation,
+} from "@/domains/items/hook/useItemDetailMutations.js"
+import PageIntro from "@/components/layout/PageIntro.jsx"
+import { useCategoriesQuery } from "@/domains/items/hook/useItemsQuery.js"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+function flattenTree(node) {
+  return [
+    { id: String(node.id), name: node.name },
+    ...(node.children ?? []).flatMap((child) => flattenTree(child)),
+  ]
+}
+
+function getRouteItemType(locationState, itemSummary) {
+  if (locationState?.itemType) return String(locationState.itemType).toUpperCase()
+  if (itemSummary?.itemType) return String(itemSummary.itemType).toUpperCase()
+  return ""
+}
+
+export default function ItemDetailPage() {
+  const { itemId } = useParams()
+  const location = useLocation()
+  const { data: productsPayload } = useSellerProductsQuery()
+  const { data: categoryTree = [] } = useCategoriesQuery()
+  const products = productsPayload?.items ?? []
+  const itemSummary = products.find((item) => String(item.id) === String(itemId)) ?? null
+  const itemType = getRouteItemType(location.state, itemSummary)
+  const detailQuery = useSellerItemDetailQuery(itemId, itemType)
+  const item = detailQuery.data
+
+  const goodsCategories = useMemo(
+    () =>
+      categoryTree
+        .filter((category) => category.name !== "공연/티켓")
+        .flatMap((category) => flattenTree(category)),
+    [categoryTree]
+  )
+  const performanceCategories = useMemo(() => {
+    const perfNode = categoryTree.find((category) => category.name === "공연/티켓")
+    return perfNode ? flattenTree(perfNode) : []
+  }, [categoryTree])
+
+  const [form, setForm] = useState(null)
+
+  useEffect(() => {
+    if (!item) return
+
+    if (item.itemType === "PERFORMANCE") {
+      const firstSeatGrade = item.seatGrades?.[0] ?? {}
+      setForm({
+        title: item.title ?? "",
+        categoryId: String(item.categoryId ?? ""),
+        price: String(item.price ?? 0),
+        description: item.description ?? "",
+        venue: item.venue ?? "",
+        performanceDate: item.performanceDate ?? "",
+        performanceTime: String(item.performanceTime ?? "").slice(0, 5),
+        totalSeats: String(item.totalSeats ?? 0),
+        runningTimeMinutes: item.runningTimeMinutes ? String(item.runningTimeMinutes) : "",
+        ageLimit: item.ageLimit ?? "",
+        venueAddress: item.venueAddress ?? "",
+        bookingNotice: item.bookingNotice ?? "",
+        organizer: item.organizer ?? "",
+        host: item.host ?? "",
+        gradeName: firstSeatGrade.gradeName ?? "일반",
+        gradePrice: String(firstSeatGrade.price ?? item.price ?? 0),
+      })
+      return
+    }
+
+    const firstOption = item?.options?.[0] ?? {}
+    const shippingInfo = item?.shippingInfo ?? {}
+    setForm({
+      title: item.title ?? "",
+      categoryId: String(item.categoryId ?? ""),
+      price: String(item.price ?? 0),
+      description: item.description ?? "",
+      optionName: firstOption.optionName ?? "기본",
+      additionalPrice: String(firstOption.additionalPrice ?? 0),
+      stockQuantity: String(firstOption.stockQuantity ?? 0),
+      shippingFee: String(shippingInfo.shippingFee ?? 0),
+      estimatedDays: String(shippingInfo.estimatedDays ?? 3),
+    })
+  }, [item])
+
+  const updateGoodsMutation = useUpdateGoodsMutation(itemId)
+  const updatePerformanceMutation = useUpdatePerformanceMutation(itemId)
+
+  const handleChange = (name, value) => {
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async () => {
+    if (!item || !form) return
+
+    if (item.itemType === "PERFORMANCE") {
+      await updatePerformanceMutation.mutateAsync({
+        title: form.title,
+        categoryId: form.categoryId ? Number(form.categoryId) : undefined,
+        price: form.price ? Number(form.price) : undefined,
+        description: form.description || undefined,
+        venue: form.venue || undefined,
+        performanceDate: form.performanceDate || undefined,
+        performanceTime: form.performanceTime ? `${form.performanceTime}:00` : undefined,
+        totalSeats: form.totalSeats ? Number(form.totalSeats) : undefined,
+        runningTimeMinutes: form.runningTimeMinutes ? Number(form.runningTimeMinutes) : undefined,
+        ageLimit: form.ageLimit || undefined,
+        venueAddress: form.venueAddress || undefined,
+        bookingNotice: form.bookingNotice || undefined,
+        organizer: form.organizer || undefined,
+        host: form.host || undefined,
+        seatGrades: [
+          {
+            gradeName: form.gradeName || "일반",
+            price: Number(form.gradePrice || form.price || 0),
+            totalQuantity: Number(form.totalSeats || 0),
+            fundingQuantity: 0,
+          },
+        ],
+      })
+      return
+    }
+
+    await updateGoodsMutation.mutateAsync({
+      title: form.title,
+      categoryId: form.categoryId ? Number(form.categoryId) : undefined,
+      price: form.price ? Number(form.price) : undefined,
+      description: form.description || undefined,
+      options: [
+        {
+          optionName: form.optionName || "기본",
+          additionalPrice: Number(form.additionalPrice || 0),
+          stockQuantity: Number(form.stockQuantity || 0),
+        },
+      ],
+      shippingInfo: {
+        shippingFee: Number(form.shippingFee || 0),
+        estimatedDays: Number(form.estimatedDays || 3),
+      },
+    })
+  }
+
+  const saveBusy = updateGoodsMutation.isPending || updatePerformanceMutation.isPending
+  const saveError = updateGoodsMutation.error || updatePerformanceMutation.error
+
+  if (detailQuery.isLoading || !form) {
+    return (
+      <div className="mx-auto flex min-h-[40vh] max-w-3xl items-center justify-center">
+        <div className="glass-panel rounded-[1.8rem] px-6 py-8 text-center text-sm text-muted-foreground">
+          상품 상세를 불러오는 중입니다.
+        </div>
+      </div>
+    )
+  }
+
+  if (!item) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <Alert variant="destructive">
+          <AlertDescription>상품 상세를 찾을 수 없습니다.</AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  const categories = item.itemType === "PERFORMANCE" ? performanceCategories : goodsCategories
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <PageIntro
+        eyebrow="Item Detail"
+        title={item.title}
+        description="상품 상세와 수정 화면입니다. 관리 목록에서 들어온 뒤 필요한 필드만 바로 수정할 수 있습니다."
+        meta={[
+          item.itemType === "PERFORMANCE" ? "공연" : "굿즈",
+          item.status ?? "상태 미정",
+          item.priceText ?? "-",
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Quick actions
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button asChild size="sm" variant="outline">
+              <Link to="/business/items">목록으로</Link>
+            </Button>
+          </div>
+        </div>
+      </PageIntro>
+
+      {saveError ? (
+        <Alert variant="destructive">
+          <AlertDescription>
+            {saveError?.message ?? "상품 수정에 실패했습니다."}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Card>
+        <CardContent className="p-6">
+          <div className="flex items-center gap-2">
+            {item.itemType === "PERFORMANCE" ? (
+              <Ticket size={18} className="text-primary" />
+            ) : (
+              <Store size={18} className="text-primary" />
+            )}
+            <h2 className="display-title text-2xl text-foreground">상세 / 수정</h2>
+            <Badge variant="outline" className="ml-auto">
+              {item.itemType}
+            </Badge>
+          </div>
+
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <Label>이름</Label>
+              <Input value={form.title} onChange={(event) => handleChange("title", event.target.value)} />
+            </div>
+
+            <div>
+              <Label>카테고리</Label>
+              <Select value={form.categoryId} onValueChange={(value) => handleChange("categoryId", value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="카테고리 선택" />
+                </SelectTrigger>
+                <SelectContent>
+                  {categories.map((category) => (
+                    <SelectItem key={category.id} value={String(category.id)}>
+                      {category.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label>가격</Label>
+              <Input type="number" value={form.price} onChange={(event) => handleChange("price", event.target.value)} />
+            </div>
+
+            {item.itemType === "PERFORMANCE" ? (
+              <>
+                <div>
+                  <Label>공연 장소</Label>
+                  <Input value={form.venue} onChange={(event) => handleChange("venue", event.target.value)} />
+                </div>
+                <div>
+                  <Label>공연장 주소</Label>
+                  <Input value={form.venueAddress} onChange={(event) => handleChange("venueAddress", event.target.value)} />
+                </div>
+                <div>
+                  <Label>공연 날짜</Label>
+                  <Input type="date" value={form.performanceDate} onChange={(event) => handleChange("performanceDate", event.target.value)} />
+                </div>
+                <div>
+                  <Label>공연 시간</Label>
+                  <Input type="time" value={form.performanceTime} onChange={(event) => handleChange("performanceTime", event.target.value)} />
+                </div>
+                <div>
+                  <Label>총 좌석 수</Label>
+                  <Input type="number" value={form.totalSeats} onChange={(event) => handleChange("totalSeats", event.target.value)} />
+                </div>
+                <div>
+                  <Label>러닝타임</Label>
+                  <Input type="number" value={form.runningTimeMinutes} onChange={(event) => handleChange("runningTimeMinutes", event.target.value)} />
+                </div>
+                <div>
+                  <Label>관람 등급</Label>
+                  <Input value={form.ageLimit} onChange={(event) => handleChange("ageLimit", event.target.value)} />
+                </div>
+                <div>
+                  <Label>주최</Label>
+                  <Input value={form.organizer} onChange={(event) => handleChange("organizer", event.target.value)} />
+                </div>
+                <div>
+                  <Label>주관</Label>
+                  <Input value={form.host} onChange={(event) => handleChange("host", event.target.value)} />
+                </div>
+                <div>
+                  <Label>좌석 등급명</Label>
+                  <Input value={form.gradeName} onChange={(event) => handleChange("gradeName", event.target.value)} />
+                </div>
+                <div>
+                  <Label>좌석 가격</Label>
+                  <Input type="number" value={form.gradePrice} onChange={(event) => handleChange("gradePrice", event.target.value)} />
+                </div>
+                <div className="sm:col-span-2">
+                  <Label>예매 안내</Label>
+                  <Textarea rows={3} value={form.bookingNotice} onChange={(event) => handleChange("bookingNotice", event.target.value)} />
+                </div>
+              </>
+            ) : (
+              <>
+                <div>
+                  <Label>옵션명</Label>
+                  <Input value={form.optionName} onChange={(event) => handleChange("optionName", event.target.value)} />
+                </div>
+                <div>
+                  <Label>추가 금액</Label>
+                  <Input type="number" value={form.additionalPrice} onChange={(event) => handleChange("additionalPrice", event.target.value)} />
+                </div>
+                <div>
+                  <Label>재고</Label>
+                  <Input type="number" value={form.stockQuantity} onChange={(event) => handleChange("stockQuantity", event.target.value)} />
+                </div>
+                <div>
+                  <Label>배송비</Label>
+                  <Input type="number" value={form.shippingFee} onChange={(event) => handleChange("shippingFee", event.target.value)} />
+                </div>
+                <div>
+                  <Label>예상 배송일</Label>
+                  <Input type="number" value={form.estimatedDays} onChange={(event) => handleChange("estimatedDays", event.target.value)} />
+                </div>
+              </>
+            )}
+
+            <div className="sm:col-span-2">
+              <Label>설명</Label>
+              <Textarea rows={5} value={form.description} onChange={(event) => handleChange("description", event.target.value)} />
+            </div>
+          </div>
+
+          <div className="mt-6 flex justify-end">
+            <Button onClick={handleSubmit} disabled={saveBusy}>
+              <Save size={14} />
+              {saveBusy ? "저장 중..." : "변경 저장"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/domains/items/page/Items.jsx
+++ b/src/domains/items/page/Items.jsx
@@ -1,13 +1,38 @@
 import { useEffect, useState } from "react"
 import { useActionState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
-import { ShoppingBag, Music, Check } from "lucide-react"
+import { AlertCircle, Check, Music, ShoppingBag, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 import { createItemAction } from "../actions/createItemAction.js"
-import { useCategoriesQuery, useMyStoreQuery } from "../hook/useItemsQuery.js"
+import { itemKeys, useCategoriesQuery, useMyStoreQuery, useSellerProductsQuery } from "../hook/useItemsQuery.js"
+import { useDeleteItemMutation, useToggleStatusMutation } from "../hook/useItemMutations.js"
 import GoodsForm from "@/components/items/GoodsForm.jsx"
 import PerformanceForm from "@/components/items/PerformanceForm.jsx"
+import PageIntro from "@/components/layout/PageIntro.jsx"
+import { demoItems } from "@/domains/management/mock/demoData.js"
+import { cn } from "@/lib/utils"
+
+const numberFormatter = new Intl.NumberFormat("ko-KR")
+
+const ITEM_TYPE_META = {
+  GOODS: "굿즈",
+  PERFORMANCE: "공연",
+}
+
+const ITEM_STATUS_META = {
+  DRAFT: { label: "초안", variant: "outline" },
+  FUNDING: { label: "펀딩 진행", variant: "secondary" },
+  FUNDED: { label: "펀딩 성공", variant: "secondary" },
+  FUND_FAILED: { label: "펀딩 실패", variant: "destructive" },
+  ON_SALE: { label: "판매 중", variant: "default" },
+  HOT_DEAL: { label: "핫딜 진행", variant: "default" },
+  HIDDEN: { label: "숨김", variant: "outline" },
+  SOLD_OUT: { label: "품절", variant: "secondary" },
+  CLOSED: { label: "종료", variant: "outline" },
+}
 
 function flattenTree(node) {
   return [
@@ -16,87 +41,286 @@ function flattenTree(node) {
   ]
 }
 
+function getItemTitle(item) {
+  return item?.title ?? item?.name ?? `상품 #${item?.id ?? "-"}`
+}
+
+function getItemType(item) {
+  return item?.itemType ?? item?.type ?? "GOODS"
+}
+
+function getItemStatus(item) {
+  return item?.status ?? "DRAFT"
+}
+
+function getItemStatusMeta(status) {
+  return ITEM_STATUS_META[status] ?? { label: status, variant: "outline" }
+}
+
+function getItemTypeLabel(item) {
+  const type = getItemType(item)
+  return ITEM_TYPE_META[type] ?? type
+}
+
+function getNextItemStatus(status) {
+  if (status === "ON_SALE") return "HIDDEN"
+  if (status === "HIDDEN" || status === "DRAFT") return "ON_SALE"
+  return null
+}
+
 export default function ItemsPage() {
+  const [formKey, setFormKey] = useState(0)
+  return <ItemsForm key={formKey} onReset={() => setFormKey((value) => value + 1)} />
+}
+
+function ItemsForm({ onReset }) {
   const [itemType, setItemType] = useState("goods")
   const [goodsCategoryId, setGoodsCategoryId] = useState("")
   const [perfCategoryId, setPerfCategoryId] = useState("")
-  const [isSuccess, setIsSuccess] = useState(false)
   const queryClient = useQueryClient()
 
   const [state, formAction, isPending] = useActionState(createItemAction, {});
 
   const { data: categoryTree = [] } = useCategoriesQuery()
   const { data: myStore } = useMyStoreQuery()
+  const { data: productsPayload } = useSellerProductsQuery()
+  const items = productsPayload?.items ?? []
+  const toggleStatusMutation = useToggleStatusMutation()
+  const deleteItemMutation = useDeleteItemMutation()
 
   const perfNode = categoryTree.find((c) => c.name === "공연/티켓")
   const perfCategories = perfNode ? flattenTree(perfNode) : []
   const goodsCategories = categoryTree
     .filter((c) => c.name !== "공연/티켓")
     .flatMap((c) => flattenTree(c))
+  const connectedStoreName = myStore?.store_name ?? myStore?.name ?? "스토어 연결 대기"
+  const activeCategoryCount =
+    itemType === "goods" ? goodsCategories.length : perfCategories.length
+  const usingDemoItems = import.meta.env.DEV && items.length === 0
+  const sourceItems = usingDemoItems ? demoItems : items
+  const activeItems = sourceItems.filter((item) =>
+    itemType === "goods" ? getItemType(item) === "GOODS" : getItemType(item) === "PERFORMANCE"
+  )
 
   useEffect(() => {
     if (state.success) {
-      queryClient.invalidateQueries({ queryKey: ["seller-products"] })
-      setGoodsCategoryId("")
-      setPerfCategoryId("")
-      setIsSuccess(true)
+      queryClient.invalidateQueries({ queryKey: itemKeys.products() })
     }
-  }, [state.success, queryClient])
+  }, [queryClient, state.success])
 
-  if (isSuccess) {
+  const handleToggleStatus = (item) => {
+    const currentStatus = getItemStatus(item)
+    const nextStatus = getNextItemStatus(currentStatus)
+    if (!nextStatus) return
+
+    toggleStatusMutation.mutate({ itemId: item.id, status: nextStatus })
+  }
+
+  const handleDelete = (item) => {
+    if (!window.confirm(`"${getItemTitle(item)}" 상품을 삭제하시겠습니까?`)) {
+      return
+    }
+    deleteItemMutation.mutate(item.id)
+  }
+
+  if (state.success) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
-          <Check size={32} className="text-primary" />
+      <div className="mx-auto flex min-h-[60vh] max-w-xl items-center justify-center">
+        <div className="glass-panel surface-hero flex w-full flex-col items-center gap-4 rounded-[2rem] px-8 py-12 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/12">
+            <Check size={32} className="text-primary" />
+          </div>
+          <h2 className="display-title text-3xl font-semibold">아이템 등록 완료!</h2>
+          <p className="max-w-md text-sm leading-6 text-muted-foreground">
+            아이템이 성공적으로 등록되었습니다. 같은 셸 안에서 다음 상품도 이어서 바로 등록할 수 있습니다.
+          </p>
+          <Button onClick={onReset}>다시 등록하기</Button>
         </div>
-        <h2 className="text-xl font-bold">아이템 등록 완료!</h2>
-        <p className="text-muted-foreground text-sm">아이템이 성공적으로 등록되었습니다.</p>
-        <Button onClick={() => setIsSuccess(false)}>다시 등록하기</Button>
       </div>
     )
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold">아이템 등록</h1>
-        <p className="text-muted-foreground text-sm mt-1">가게에서 판매할 아이템을 등록하세요.</p>
-      </div>
-
-      <Card className="bg-card border border-border rounded-xl overflow-hidden">
-        <div className="flex items-center gap-2 px-6 py-4 border-b border-border">
-          <div className="w-1 h-4 bg-primary rounded-full" />
-          <h3 className="font-semibold text-sm">새 아이템 등록</h3>
+    <div className="mx-auto max-w-6xl space-y-6">
+      <PageIntro
+        eyebrow="Catalog Management"
+        title="상품 관리"
+        description="굿즈와 공연 상품을 하나의 인터페이스 안에서 관리하도록 재정렬했습니다. 기존 데이터 바인딩은 유지한 채, 등록과 운영을 한 화면 흐름으로 묶었습니다."
+        meta={[
+          itemType === "goods" ? "굿즈 모드" : "공연 모드",
+          `카테고리 ${activeCategoryCount}개`,
+          `${items.length}개 상품 관리 중`,
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Store context
+          </p>
+          <p className="mt-3 text-lg font-semibold text-foreground">
+            {connectedStoreName}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            {itemType === "goods"
+              ? "실물 상품의 가격, 재고, 설명을 중심으로 구성합니다."
+              : "공연명, 장소, 일정, 좌석 등급을 한 번에 정리합니다."}
+          </p>
         </div>
+      </PageIntro>
 
-        <div className="px-6 pt-5">
-          <div className="flex gap-2 p-1 bg-muted rounded-lg w-full">
-            <button
-              type="button"
-              onClick={() => setItemType("goods")}
-              className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-colors ${
-                itemType === "goods"
-                  ? "bg-primary text-primary-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              <ShoppingBag size={14} /> 굿즈
-            </button>
-            <button
-              type="button"
-              onClick={() => setItemType("performance")}
-              className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-colors ${
-                itemType === "performance"
-                  ? "bg-primary text-primary-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              <Music size={14} /> 공연
-            </button>
+      <Card className="overflow-hidden">
+        <div className="flex flex-col gap-4 border-b border-white/70 px-6 py-5 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="section-kicker">Current inventory</p>
+            <h2 className="display-title mt-2 text-2xl text-foreground">등록된 상품</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              현재 등록된 상품 상태를 먼저 확인하고, 필요한 경우 새 상품을 추가합니다.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            {usingDemoItems ? <Badge variant="outline">데모 데이터</Badge> : null}
+            <div className="metric-chip flex w-full max-w-md gap-2 rounded-full p-1.5">
+              <button
+                type="button"
+                onClick={() => setItemType("goods")}
+                className={cn(
+                  "flex-1 rounded-full px-4 py-2.5 text-sm font-semibold transition-all",
+                  itemType === "goods"
+                    ? "bg-primary text-primary-foreground shadow-[0_12px_24px_rgba(29,161,242,0.18)]"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <span className="flex items-center justify-center gap-2">
+                  <ShoppingBag size={15} /> 굿즈
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setItemType("performance")}
+                className={cn(
+                  "flex-1 rounded-full px-4 py-2.5 text-sm font-semibold transition-all",
+                  itemType === "performance"
+                    ? "bg-primary text-primary-foreground shadow-[0_12px_24px_rgba(29,161,242,0.18)]"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <span className="flex items-center justify-center gap-2">
+                  <Music size={15} /> 공연
+                </span>
+              </button>
+            </div>
           </div>
         </div>
 
-        <div className="px-6 pb-6 pt-4">
+        <CardContent className="p-6">
+          {activeItems.length > 0 ? (
+            <div className="grid gap-4 lg:grid-cols-2">
+              {activeItems.map((item) => {
+                const status = getItemStatus(item)
+                const statusMeta = getItemStatusMeta(status)
+                const nextStatus = getNextItemStatus(status)
+                const busy =
+                  !usingDemoItems &&
+                  (toggleStatusMutation.isPending || deleteItemMutation.isPending)
+
+                return (
+                  <div key={item.id} className="metric-chip rounded-[1.6rem] px-5 py-5">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-base font-semibold text-foreground">
+                          {getItemTitle(item)}
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          <Badge variant="outline">{getItemTypeLabel(item)}</Badge>
+                          <Badge variant={statusMeta.variant}>{statusMeta.label}</Badge>
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-xs uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                          Price
+                        </p>
+                        <p className="mt-1 text-sm font-semibold text-primary">
+                          {item?.price ? `${numberFormatter.format(item.price)}원` : "-"}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                      <div>
+                        <p className="text-[0.72rem] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                          Reviews
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          평점 {item?.averageRating ?? 0} / 리뷰 {item?.reviewCount ?? 0}개
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-[0.72rem] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                          Item ID
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">{item.id}</p>
+                      </div>
+                    </div>
+
+                    <div className="mt-5 flex flex-wrap gap-2">
+                      {nextStatus ? (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleToggleStatus(item)}
+                          disabled={busy || usingDemoItems}
+                        >
+                          {status === "ON_SALE" ? "숨김 처리" : "판매 시작"}
+                        </Button>
+                      ) : null}
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => handleDelete(item)}
+                        disabled={busy || usingDemoItems}
+                      >
+                        <Trash2 size={14} />
+                        삭제
+                      </Button>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="rounded-[1.8rem] border border-dashed border-border px-6 py-10 text-center">
+              <AlertCircle size={24} className="mx-auto text-primary/70" />
+              <h3 className="mt-4 text-lg font-semibold text-foreground">
+                아직 등록된 {itemType === "goods" ? "굿즈" : "공연"}가 없습니다
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                아래 신규 등록 폼에서 바로 추가할 수 있습니다.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {!usingDemoItems && (toggleStatusMutation.isError || deleteItemMutation.isError) && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            상품 관리 요청에 실패했습니다. 잠시 후 다시 시도해주세요.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Card className="overflow-hidden">
+        <div className="flex flex-col gap-4 border-b border-white/70 px-6 py-5 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="section-kicker">Create inventory</p>
+            <h2 className="display-title mt-2 text-2xl text-foreground">새 상품 등록</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              관리 목록에 없는 새 상품을 추가할 때만 이 폼을 사용합니다.
+            </p>
+          </div>
+        </div>
+
+        <div className="px-6 py-6">
           {itemType === "goods" && (
             <GoodsForm
               state={state}

--- a/src/domains/items/page/Items.jsx
+++ b/src/domains/items/page/Items.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { useActionState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { AlertCircle, Check, Music, ShoppingBag, Trash2 } from "lucide-react"
+import { Link } from "react-router"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -263,6 +264,15 @@ function ItemsForm({ onReset }) {
                     </div>
 
                     <div className="mt-5 flex flex-wrap gap-2">
+                      <Button
+                        asChild
+                        size="sm"
+                        variant="outline"
+                      >
+                        <Link to={`/business/items/${item.id}`} state={{ itemType: getItemType(item) }}>
+                          상세/수정
+                        </Link>
+                      </Button>
                       {nextStatus ? (
                         <Button
                           size="sm"

--- a/src/domains/management/mock/demoBackend.js
+++ b/src/domains/management/mock/demoBackend.js
@@ -191,6 +191,86 @@ export function demoGetSellerProducts() {
   return { items: seededProducts }
 }
 
+function buildDefaultGoodsDetail(item) {
+  const option = item?.options?.[0] ?? {
+    id: `${item?.id}-opt-1`,
+    optionName: "기본",
+    additionalPrice: 0,
+    stockQuantity: item?.stockQuantity ?? 50,
+  }
+  const shippingInfo = item?.shippingInfo ?? {
+    shippingFee: 0,
+    estimatedDays: 3,
+  }
+
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.description ?? "",
+    price: item.price,
+    status: item.status,
+    itemType: "GOODS",
+    averageRating: item.averageRating ?? 0,
+    reviewCount: item.reviewCount ?? 0,
+    categoryId: item.categoryId ?? 101,
+    categoryName: "의류",
+    sellerId: DEMO_USER_ID,
+    storeId: item.storeId ?? 70001,
+    options: [option],
+    shippingInfo,
+  }
+}
+
+function buildDefaultPerformanceDetail(item) {
+  const seatGrade = item?.seatGrades?.[0] ?? {
+    id: `${item?.id}-seat-1`,
+    gradeName: "일반",
+    price: item.price,
+    totalQuantity: item.totalSeats ?? 300,
+    fundingQuantity: 0,
+  }
+
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.description ?? "",
+    price: item.price,
+    status: item.status,
+    itemType: "PERFORMANCE",
+    averageRating: item.averageRating ?? 0,
+    reviewCount: item.reviewCount ?? 0,
+    categoryId: item.categoryId ?? 201,
+    categoryName: "콘서트",
+    sellerId: DEMO_USER_ID,
+    storeId: item.storeId ?? 70001,
+    venue: item.venue ?? "돈모아 홀",
+    performanceDate: item.performanceDate ?? "2026-04-30",
+    performanceTime: item.performanceTime ?? "19:00:00",
+    totalSeats: item.totalSeats ?? 300,
+    runningTimeMinutes: item.runningTimeMinutes ?? 110,
+    ageLimit: item.ageLimit ?? "전체 관람가",
+    venueAddress: item.venueAddress ?? "서울특별시 마포구",
+    bookingNotice: item.bookingNotice ?? "공연 시작 후 입장이 제한될 수 있습니다.",
+    organizer: item.organizer ?? "돈모아",
+    host: item.host ?? "돈모아 라이브",
+    seatGrades: [seatGrade],
+  }
+}
+
+export function demoGetSellerGoodsDetail(itemId) {
+  const item = demoGetSellerProducts().items.find(
+    (product) => Number(product.id) === Number(itemId) && product.itemType === "GOODS"
+  )
+  return item ? buildDefaultGoodsDetail(item) : null
+}
+
+export function demoGetSellerPerformanceDetail(itemId) {
+  const item = demoGetSellerProducts().items.find(
+    (product) => Number(product.id) === Number(itemId) && product.itemType === "PERFORMANCE"
+  )
+  return item ? buildDefaultPerformanceDetail(item) : null
+}
+
 export function demoCreateGoods(payload) {
   const nextState = updateState((state) => {
     const itemId = nextId(state, "item")
@@ -256,6 +336,57 @@ export function demoDeleteProduct(itemId) {
   return { success: true }
 }
 
+export function demoUpdateGoods(itemId, payload) {
+  const nextState = updateState((state) => {
+    state.products = state.products.map((item) =>
+      Number(item.id) === Number(itemId)
+        ? {
+            ...item,
+            title: payload.title ?? item.title,
+            description: payload.description ?? item.description,
+            price: payload.price ?? item.price,
+            categoryId: payload.categoryId ?? item.categoryId,
+            options: payload.options ?? item.options,
+            shippingInfo: payload.shippingInfo ?? item.shippingInfo,
+          }
+        : item
+    )
+    return state
+  })
+
+  return demoGetSellerGoodsDetail(itemId) ?? nextState.products.find((item) => Number(item.id) === Number(itemId)) ?? null
+}
+
+export function demoUpdatePerformance(itemId, payload) {
+  const nextState = updateState((state) => {
+    state.products = state.products.map((item) =>
+      Number(item.id) === Number(itemId)
+        ? {
+            ...item,
+            title: payload.title ?? item.title,
+            description: payload.description ?? item.description,
+            price: payload.price ?? item.price,
+            categoryId: payload.categoryId ?? item.categoryId,
+            venue: payload.venue ?? item.venue,
+            performanceDate: payload.performanceDate ?? item.performanceDate,
+            performanceTime: payload.performanceTime ?? item.performanceTime,
+            totalSeats: payload.totalSeats ?? item.totalSeats,
+            runningTimeMinutes: payload.runningTimeMinutes ?? item.runningTimeMinutes,
+            ageLimit: payload.ageLimit ?? item.ageLimit,
+            venueAddress: payload.venueAddress ?? item.venueAddress,
+            bookingNotice: payload.bookingNotice ?? item.bookingNotice,
+            organizer: payload.organizer ?? item.organizer,
+            host: payload.host ?? item.host,
+            seatGrades: payload.seatGrades ?? item.seatGrades,
+          }
+        : item
+    )
+    return state
+  })
+
+  return demoGetSellerPerformanceDetail(itemId) ?? nextState.products.find((item) => Number(item.id) === Number(itemId)) ?? null
+}
+
 export function demoGetCampaigns() {
   const state = readState()
   return {
@@ -316,6 +447,23 @@ export function demoCancelCampaign(campaignId) {
 
 export function demoGetCampaignById(campaignId) {
   return demoGetCampaigns().content.find((campaign) => Number(campaign.id) === Number(campaignId)) ?? null
+}
+
+export function demoUpdateCampaign(campaignId, payload) {
+  const nextState = updateState((state) => {
+    state.campaigns = state.campaigns.map((campaign) =>
+      Number(campaign.id) === Number(campaignId)
+        ? {
+            ...campaign,
+            ...payload,
+            updatedAt: new Date().toISOString(),
+          }
+        : campaign
+    )
+    return state
+  })
+
+  return nextState.campaigns.find((campaign) => Number(campaign.id) === Number(campaignId)) ?? null
 }
 
 export function demoGetCampaignByItemId(itemId) {

--- a/src/domains/management/mock/demoBackend.js
+++ b/src/domains/management/mock/demoBackend.js
@@ -1,0 +1,462 @@
+import {
+  demoCampaigns,
+  demoChatMessagesByRoomId,
+  demoChatRooms,
+  demoHotDealItems,
+  demoItems,
+  demoReviewsByItemId,
+} from "@/domains/management/mock/demoData.js"
+
+const DEMO_MODE_KEY = "donmoa-business:demo-mode"
+const DEMO_STATE_KEY = "donmoa-business:demo-state:v1"
+const DEMO_USER_ID = 504
+
+const DEMO_CATEGORIES = [
+  {
+    id: 1,
+    name: "굿즈",
+    children: [
+      { id: 101, name: "의류", children: [] },
+      { id: 102, name: "액세서리", children: [] },
+      { id: 103, name: "문구", children: [] },
+    ],
+  },
+  {
+    id: 2,
+    name: "공연/티켓",
+    children: [
+      { id: 201, name: "콘서트", children: [] },
+      { id: 202, name: "팬미팅", children: [] },
+      { id: 203, name: "전시", children: [] },
+    ],
+  },
+]
+
+function buildDefaultState() {
+  return {
+    store: null,
+    products: [],
+    campaigns: [],
+    hotDeals: [],
+    reviewsByItemId: structuredClone(demoReviewsByItemId),
+    chatRooms: structuredClone(demoChatRooms),
+    chatMessagesByRoomId: structuredClone(demoChatMessagesByRoomId),
+    categories: structuredClone(DEMO_CATEGORIES),
+    counters: {
+      store: 70001,
+      item: 95000,
+      campaign: 76000,
+      hotDeal: 86000,
+      message: 99020,
+      room: 80010,
+    },
+  }
+}
+
+function canUseStorage() {
+  return typeof window !== "undefined" && Boolean(window.localStorage)
+}
+
+function persistDemoFlag(value) {
+  if (!canUseStorage()) return
+  if (value) {
+    window.localStorage.setItem(DEMO_MODE_KEY, "true")
+  } else {
+    window.localStorage.removeItem(DEMO_MODE_KEY)
+  }
+}
+
+export function isDemoModeEnabled() {
+  if (import.meta.env.VITE_DEMO_MODE === "true") {
+    return true
+  }
+
+  if (typeof window === "undefined") {
+    return false
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  if (params.get("demo") === "1") {
+    persistDemoFlag(true)
+    return true
+  }
+  if (params.get("demo") === "0") {
+    persistDemoFlag(false)
+    return false
+  }
+
+  return window.localStorage.getItem(DEMO_MODE_KEY) === "true"
+}
+
+function readState() {
+  if (!canUseStorage()) return buildDefaultState()
+  const raw = window.localStorage.getItem(DEMO_STATE_KEY)
+  if (!raw) return buildDefaultState()
+
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return buildDefaultState()
+  }
+}
+
+function writeState(state) {
+  if (!canUseStorage()) return
+  window.localStorage.setItem(DEMO_STATE_KEY, JSON.stringify(state))
+}
+
+function updateState(updater) {
+  const current = readState()
+  const next = updater(current)
+  writeState(next)
+  return next
+}
+
+function nextId(state, key) {
+  const current = state.counters[key] ?? 1
+  state.counters[key] = current + 1
+  return current
+}
+
+function mapHotDealsToProductItems(hotDeals) {
+  return hotDeals.map((item) => ({
+    ...item,
+    sellerId: DEMO_USER_ID,
+    storeId: 70001,
+  }))
+}
+
+function normalizeStoreResponse(store) {
+  if (!store) return null
+  return {
+    ...store,
+    store_name: store.storeName,
+    addresses: store.addresses ?? [],
+    contacts: store.contacts ?? [],
+  }
+}
+
+export function demoGetMyStore() {
+  return normalizeStoreResponse(readState().store)
+}
+
+export function demoCreateStore(payload) {
+  const nextState = updateState((state) => {
+    if (state.store) {
+      throw new Error("이미 등록된 가게입니다.")
+    }
+
+    const storeId = nextId(state, "store")
+    state.store = {
+      id: storeId,
+      userId: DEMO_USER_ID,
+      storeName: payload.storeName,
+      status: "ACTIVE",
+      description: payload.description ?? "",
+      addresses: [
+        {
+          id: storeId * 10 + 1,
+          address_type: payload.addressType,
+          address: payload.address,
+          detail_address: "",
+          is_default: true,
+        },
+      ],
+      contacts: [
+        {
+          id: storeId * 10 + 2,
+          contact_type: payload.contactType,
+          contact_value: payload.contactValue,
+          is_primary: true,
+        },
+      ],
+    }
+    return state
+  })
+
+  return normalizeStoreResponse(nextState.store)
+}
+
+export function demoGetCategories() {
+  return readState().categories
+}
+
+export function demoGetSellerProducts() {
+  const state = readState()
+  const seededProducts =
+    state.products.length > 0
+      ? state.products
+      : mapHotDealsToProductItems(demoItems.concat(demoHotDealItems))
+
+  return { items: seededProducts }
+}
+
+export function demoCreateGoods(payload) {
+  const nextState = updateState((state) => {
+    const itemId = nextId(state, "item")
+    state.products.unshift({
+      id: itemId,
+      title: payload.title,
+      price: Number(payload.price),
+      itemType: "GOODS",
+      status: "DRAFT",
+      averageRating: 0,
+      reviewCount: 0,
+      sellerId: DEMO_USER_ID,
+      storeId: Number(payload.storeId),
+    })
+    return state
+  })
+
+  return nextState.products[0]
+}
+
+export function demoCreatePerformance(payload) {
+  const nextState = updateState((state) => {
+    const itemId = nextId(state, "item")
+    state.products.unshift({
+      id: itemId,
+      title: payload.title,
+      price: Number(payload.price),
+      itemType: "PERFORMANCE",
+      status: "DRAFT",
+      averageRating: 0,
+      reviewCount: 0,
+      sellerId: DEMO_USER_ID,
+      storeId: Number(payload.storeId),
+      venue: payload.venue,
+      performanceDate: payload.performanceDate,
+    })
+    return state
+  })
+
+  return nextState.products[0]
+}
+
+export function demoToggleProductStatus(itemId, status) {
+  const nextState = updateState((state) => {
+    state.products = state.products.map((item) =>
+      Number(item.id) === Number(itemId) ? { ...item, status } : item
+    )
+    return state
+  })
+
+  return nextState.products.find((item) => Number(item.id) === Number(itemId)) ?? null
+}
+
+export function demoDeleteProduct(itemId) {
+  updateState((state) => {
+    state.products = state.products.filter((item) => Number(item.id) !== Number(itemId))
+    state.campaigns = state.campaigns.filter((campaign) => Number(campaign.itemId) !== Number(itemId))
+    state.hotDeals = state.hotDeals.filter((deal) => Number(deal.itemId) !== Number(itemId))
+    delete state.reviewsByItemId[String(itemId)]
+    return state
+  })
+
+  return { success: true }
+}
+
+export function demoGetCampaigns() {
+  const state = readState()
+  return {
+    content: state.campaigns.length > 0 ? state.campaigns : structuredClone(demoCampaigns),
+    nextCursor: null,
+  }
+}
+
+export function demoCreateCampaign(payload) {
+  const nextState = updateState((state) => {
+    const campaignId = nextId(state, "campaign")
+    state.campaigns.unshift({
+      id: campaignId,
+      itemId: Number(payload.itemId),
+      sellerId: DEMO_USER_ID,
+      title: payload.title || "새 펀딩 캠페인",
+      summary: payload.summary || "",
+      makerName: payload.makerName || "돈모아",
+      category: payload.category || "",
+      fundingType: payload.fundingType,
+      goalAmount: payload.goalAmount ?? 0,
+      currentAmount: 0,
+      goalQuantity: payload.goalQuantity ?? null,
+      currentQuantity: 0,
+      minAmount: payload.minAmount ?? 0,
+      status: "ACTIVE",
+      startAt: payload.startAt,
+      endAt: payload.endAt,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })
+    state.products = state.products.map((item) =>
+      Number(item.id) === Number(payload.itemId) ? { ...item, status: "FUNDING" } : item
+    )
+    return state
+  })
+
+  return nextState.campaigns[0]
+}
+
+export function demoCancelCampaign(campaignId) {
+  const nextState = updateState((state) => {
+    const target = state.campaigns.find((campaign) => Number(campaign.id) === Number(campaignId))
+    if (target) {
+      target.status = "CANCELLED"
+      target.updatedAt = new Date().toISOString()
+      state.products = state.products.map((item) =>
+        Number(item.id) === Number(target.itemId) && item.status === "FUNDING"
+          ? { ...item, status: "ON_SALE" }
+          : item
+      )
+    }
+    return state
+  })
+
+  return nextState.campaigns.find((campaign) => Number(campaign.id) === Number(campaignId)) ?? null
+}
+
+export function demoGetCampaignById(campaignId) {
+  return demoGetCampaigns().content.find((campaign) => Number(campaign.id) === Number(campaignId)) ?? null
+}
+
+export function demoGetCampaignByItemId(itemId) {
+  return demoGetCampaigns().content.find((campaign) => Number(campaign.itemId) === Number(itemId)) ?? null
+}
+
+export function demoGetCampaignProgress(campaignId) {
+  const campaign = demoGetCampaignById(campaignId)
+  if (!campaign) return null
+
+  if (campaign.fundingType === "QUANTITY_BASED") {
+    return {
+      currentQuantity: campaign.currentQuantity ?? 0,
+      goalQuantity: campaign.goalQuantity ?? 0,
+      progressRate:
+        campaign.goalQuantity && campaign.goalQuantity > 0
+          ? Math.round(((campaign.currentQuantity ?? 0) / campaign.goalQuantity) * 100)
+          : 0,
+    }
+  }
+
+  return {
+    currentAmount: campaign.currentAmount ?? 0,
+    goalAmount: campaign.goalAmount ?? 0,
+    progressRate:
+      campaign.goalAmount && campaign.goalAmount > 0
+        ? Math.round(((campaign.currentAmount ?? 0) / campaign.goalAmount) * 100)
+        : 0,
+  }
+}
+
+export function demoCreateHotDeal(payload) {
+  const nextState = updateState((state) => {
+    const item = state.products.find((product) => Number(product.id) === Number(payload.itemId))
+    const hotDealId = nextId(state, "hotDeal")
+    state.hotDeals.unshift({
+      id: hotDealId,
+      itemId: Number(payload.itemId),
+      title: item?.title ?? "새 핫딜",
+      discountRate: Number(payload.discountRate),
+      discountedPrice: item?.price
+        ? Math.floor((Number(item.price) * (100 - Number(payload.discountRate))) / 100)
+        : 0,
+      soldQuantity: 0,
+      maxQuantity: Number(payload.maxQuantity),
+      endAt: payload.endAt ?? null,
+    })
+    state.products = state.products.map((product) =>
+      Number(product.id) === Number(payload.itemId)
+        ? { ...product, status: "HOT_DEAL" }
+        : product
+    )
+    return state
+  })
+
+  return nextState.hotDeals[0]
+}
+
+export function demoGetHotDeals() {
+  const state = readState()
+  return state.hotDeals
+}
+
+export function demoGetHotDealById(hotDealId) {
+  return readState().hotDeals.find((deal) => Number(deal.id) === Number(hotDealId)) ?? null
+}
+
+export function demoGetItemReviews(itemId) {
+  const reviews = readState().reviewsByItemId[String(itemId)] ?? []
+  return {
+    content: reviews,
+    totalElements: reviews.length,
+    totalPages: 1,
+    size: reviews.length,
+    number: 0,
+  }
+}
+
+export function demoFetchMyChatRooms() {
+  return {
+    items: readState().chatRooms,
+    nextCursor: null,
+    hasNext: false,
+  }
+}
+
+export function demoFetchChatMessages(roomId) {
+  return {
+    items: readState().chatMessagesByRoomId[String(roomId)] ?? [],
+    nextCursor: null,
+    hasNext: false,
+  }
+}
+
+export function demoSendChatRoomMessage(roomId, payload) {
+  const nextState = updateState((state) => {
+    const messageId = nextId(state, "message")
+    const roomKey = String(roomId)
+    const nextMessage = {
+      messageId: String(messageId),
+      senderId: String(DEMO_USER_ID),
+      messageType: payload.messageType,
+      content: payload.content,
+      createdAt: new Date().toISOString(),
+    }
+
+    const existing = state.chatMessagesByRoomId[roomKey] ?? []
+    state.chatMessagesByRoomId[roomKey] = [...existing, nextMessage]
+    state.chatRooms = state.chatRooms.map((room) =>
+      String(room.roomId) === roomKey
+        ? {
+            ...room,
+            updatedAt: nextMessage.createdAt,
+            unreadCount: 0,
+            lastMessage: {
+              messageId: nextMessage.messageId,
+              content: nextMessage.content,
+              createdAt: nextMessage.createdAt,
+            },
+          }
+        : room
+    )
+    return state
+  })
+
+  const roomMessages = nextState.chatMessagesByRoomId[String(roomId)] ?? []
+  return roomMessages[roomMessages.length - 1] ?? null
+}
+
+export function demoUpdateChatReadPointer(roomId, lastReadMessageId) {
+  updateState((state) => {
+    state.chatRooms = state.chatRooms.map((room) =>
+      String(room.roomId) === String(roomId)
+        ? { ...room, lastReadMessageId: String(lastReadMessageId), unreadCount: 0 }
+        : room
+    )
+    return state
+  })
+
+  return {
+    roomId: String(roomId),
+    lastReadMessageId: String(lastReadMessageId),
+  }
+}

--- a/src/domains/management/mock/demoData.js
+++ b/src/domains/management/mock/demoData.js
@@ -63,6 +63,7 @@ export const demoCampaigns = [
 
 export const demoHotDealItems = [
   {
+    hotDealId: 86001,
     id: 93001,
     title: "돈모아 봄 한정 포토팩",
     itemType: "GOODS",
@@ -72,6 +73,7 @@ export const demoHotDealItems = [
     reviewCount: 92,
   },
   {
+    hotDealId: 86002,
     id: 93002,
     title: "돈모아 쇼케이스 얼리버드",
     itemType: "PERFORMANCE",

--- a/src/domains/management/mock/demoData.js
+++ b/src/domains/management/mock/demoData.js
@@ -1,0 +1,201 @@
+export const demoItems = [
+  {
+    id: 91001,
+    title: "돈모아 시그니처 티셔츠",
+    itemType: "GOODS",
+    status: "ON_SALE",
+    price: 32000,
+    averageRating: 4.8,
+    reviewCount: 124,
+  },
+  {
+    id: 91002,
+    title: "돈모아 아크릴 키링 세트",
+    itemType: "GOODS",
+    status: "HIDDEN",
+    price: 18000,
+    averageRating: 4.6,
+    reviewCount: 48,
+  },
+  {
+    id: 92001,
+    title: "돈모아 라이브 쇼케이스",
+    itemType: "PERFORMANCE",
+    status: "ON_SALE",
+    price: 77000,
+    averageRating: 4.9,
+    reviewCount: 312,
+  },
+]
+
+export const demoCampaigns = [
+  {
+    id: 71001,
+    itemId: 91001,
+    title: "시그니처 티셔츠 1차 펀딩",
+    fundingType: "AMOUNT_BASED",
+    goalAmount: 5000000,
+    currentAmount: 3580000,
+    goalQuantity: null,
+    currentQuantity: null,
+    status: "ACTIVE",
+    startAt: "2026-03-01T10:00:00",
+    endAt: "2026-03-31T23:59:00",
+    makerName: "돈모아 스튜디오",
+    summary: "첫 제작 물량 확보를 위한 시그니처 굿즈 펀딩 예시 데이터입니다.",
+  },
+  {
+    id: 71002,
+    itemId: 92001,
+    title: "쇼케이스 좌석 선오픈",
+    fundingType: "QUANTITY_BASED",
+    goalAmount: null,
+    currentAmount: null,
+    goalQuantity: 400,
+    currentQuantity: 286,
+    status: "SUCCEEDED",
+    startAt: "2026-02-10T10:00:00",
+    endAt: "2026-02-20T23:59:00",
+    makerName: "돈모아 공연팀",
+    summary: "공연형 상품의 수량 기반 펀딩 예시 데이터입니다.",
+  },
+]
+
+export const demoHotDealItems = [
+  {
+    id: 93001,
+    title: "돈모아 봄 한정 포토팩",
+    itemType: "GOODS",
+    status: "HOT_DEAL",
+    price: 12000,
+    averageRating: 4.7,
+    reviewCount: 92,
+  },
+  {
+    id: 93002,
+    title: "돈모아 쇼케이스 얼리버드",
+    itemType: "PERFORMANCE",
+    status: "HOT_DEAL",
+    price: 55000,
+    averageRating: 4.9,
+    reviewCount: 141,
+  },
+]
+
+export const demoReviewsByItemId = {
+  "91001": [
+    {
+      id: 50001,
+      userId: 2101,
+      rating: 5,
+      title: "원단 퀄리티가 좋아요",
+      content: "핏이 깔끔하고 두께감이 적당해서 만족스럽습니다.",
+      createdAt: "2026-03-12T14:20:00",
+    },
+    {
+      id: 50002,
+      userId: 2102,
+      rating: 4,
+      title: "배송 빠름",
+      content: "생각보다 빨리 도착했고 프린팅 상태도 괜찮았습니다.",
+      createdAt: "2026-03-10T18:05:00",
+    },
+  ],
+  "92001": [
+    {
+      id: 50003,
+      userId: 3101,
+      rating: 5,
+      title: "현장 몰입감 최고",
+      content: "좌석 안내와 입장 동선이 좋아서 공연 보기 편했습니다.",
+      createdAt: "2026-03-08T19:40:00",
+    },
+    {
+      id: 50004,
+      userId: 3102,
+      rating: 5,
+      title: "재관람 의사 있어요",
+      content: "MD 구성도 좋고 현장 운영이 안정적이었습니다.",
+      createdAt: "2026-03-05T11:00:00",
+    },
+  ],
+}
+
+export const demoChatRooms = [
+  {
+    roomId: "80001",
+    roomType: "INQUIRY_1TO1",
+    status: "ACTIVE",
+    itemId: "91001",
+    title: "돈모아 시그니처 티셔츠 문의",
+    storeId: "70001",
+    storeName: "돈모아",
+    buyerDisplayName: "고객 A",
+    unreadCount: 2,
+    updatedAt: "2026-03-21T13:12:00",
+    lastMessage: {
+      messageId: "99003",
+      content: "사이즈 재입고 예정 있나요?",
+      createdAt: "2026-03-21T13:12:00",
+    },
+  },
+  {
+    roomId: "80002",
+    roomType: "INQUIRY_1TO1",
+    status: "ACTIVE",
+    itemId: "92001",
+    title: "돈모아 라이브 쇼케이스 문의",
+    storeId: "70001",
+    storeName: "돈모아",
+    buyerDisplayName: "고객 B",
+    unreadCount: 0,
+    updatedAt: "2026-03-20T09:48:00",
+    lastMessage: {
+      messageId: "99006",
+      content: "공연 시작 30분 전 입장 가능합니다.",
+      createdAt: "2026-03-20T09:48:00",
+    },
+  },
+]
+
+export const demoChatMessagesByRoomId = {
+  "80001": [
+    {
+      messageId: "99001",
+      senderId: "4101",
+      messageType: "CHAT",
+      content: "안녕하세요. 티셔츠 M 사이즈 품절인가요?",
+      createdAt: "2026-03-21T12:40:00",
+    },
+    {
+      messageId: "99002",
+      senderId: "504",
+      messageType: "CHAT",
+      content: "현재 M 사이즈는 품절이고 다음 주 재입고 예정입니다.",
+      createdAt: "2026-03-21T12:52:00",
+    },
+    {
+      messageId: "99003",
+      senderId: "4101",
+      messageType: "CHAT",
+      content: "사이즈 재입고 예정 있나요?",
+      createdAt: "2026-03-21T13:12:00",
+    },
+  ],
+  "80002": [
+    {
+      messageId: "99004",
+      senderId: "4202",
+      messageType: "CHAT",
+      content: "쇼케이스 입장은 언제부터 가능한가요?",
+      createdAt: "2026-03-20T09:21:00",
+    },
+    {
+      messageId: "99005",
+      senderId: "504",
+      messageType: "CHAT",
+      content: "공연 시작 30분 전부터 입장 가능합니다.",
+      createdAt: "2026-03-20T09:48:00",
+    },
+  ],
+}

--- a/src/domains/reviews/api/reviewApi.js
+++ b/src/domains/reviews/api/reviewApi.js
@@ -1,0 +1,10 @@
+import apiInstance from "@/common/api/apiInstance.js"
+import { demoGetItemReviews, isDemoModeEnabled } from "@/domains/management/mock/demoBackend.js"
+
+export async function getItemReviews(itemId, params = {}) {
+  if (isDemoModeEnabled()) {
+    return demoGetItemReviews(itemId, params)
+  }
+  const { data } = await apiInstance.get(`/v1/reviews/items/${itemId}`, { params })
+  return data?.data ?? { content: [], totalElements: 0, totalPages: 0, size: 20, number: 0 }
+}

--- a/src/domains/reviews/hook/useReviewQuery.js
+++ b/src/domains/reviews/hook/useReviewQuery.js
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { getItemReviews } from "@/domains/reviews/api/reviewApi.js"
+
+export function useItemReviewsQuery(itemId, params = {}) {
+  return useQuery({
+    queryKey: ["reviews", itemId, params],
+    queryFn: () => getItemReviews(itemId, params),
+    enabled: Boolean(itemId),
+  })
+}

--- a/src/domains/reviews/page/Reviews.jsx
+++ b/src/domains/reviews/page/Reviews.jsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from "react"
+import { MessageSquareQuote, Star } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import PageIntro from "@/components/layout/PageIntro.jsx"
+import { useSellerProductsQuery } from "@/domains/items/hook/useItemsQuery.js"
+import { useItemReviewsQuery } from "@/domains/reviews/hook/useReviewQuery.js"
+import { demoItems, demoReviewsByItemId } from "@/domains/management/mock/demoData.js"
+import { cn } from "@/lib/utils"
+
+function formatDate(value) {
+  if (!value) return "-"
+  return value.replace("T", " ").slice(0, 16)
+}
+
+function renderStars(rating = 0) {
+  const safe = Math.max(0, Math.min(5, Number(rating) || 0))
+  return "★".repeat(Math.round(safe)) + "☆".repeat(5 - Math.round(safe))
+}
+
+export default function ReviewsPage() {
+  const [selectedItemId, setSelectedItemId] = useState("")
+  const { data: productsPayload } = useSellerProductsQuery()
+  const items = productsPayload?.items ?? []
+  const usingDemoReviews = import.meta.env.DEV && items.length === 0
+  const sourceItems = usingDemoReviews ? demoItems : items
+  const reviewEnabledItems = sourceItems.filter((item) => (item?.reviewCount ?? 0) > 0)
+  const activeItemId = reviewEnabledItems.some((item) => String(item.id) === String(selectedItemId))
+    ? String(selectedItemId)
+    : String(reviewEnabledItems[0]?.id ?? "")
+  const selectedItem = reviewEnabledItems.find((item) => String(item.id) === activeItemId) ?? null
+  const reviewsQuery = useItemReviewsQuery(activeItemId, { page: 0, size: 20 })
+  const reviews = useMemo(() => {
+    if (usingDemoReviews) {
+      return demoReviewsByItemId[activeItemId] ?? []
+    }
+    return reviewsQuery.data?.content ?? []
+  }, [activeItemId, reviewsQuery.data?.content, usingDemoReviews])
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6">
+      <PageIntro
+        eyebrow="Review Management"
+        title="리뷰 관리"
+        description="내 상품에 달린 리뷰를 한곳에서 확인하는 화면입니다. 상품별 평점과 리뷰 수를 먼저 보고, 선택한 상품의 상세 리뷰를 오른쪽에서 확인할 수 있습니다."
+        meta={[
+          `${reviewEnabledItems.length}개 리뷰 대상 상품`,
+          selectedItem ? `${selectedItem.reviewCount ?? 0}개 리뷰` : "상품 선택 필요",
+          usingDemoReviews ? "데모 데이터" : "실데이터",
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Review focus
+          </p>
+          <p className="mt-3 text-lg font-semibold text-foreground">
+            상품별 리뷰 흐름 확인
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            seller 전용 리뷰 API가 없어도, 내 상품 기준으로 리뷰를 모아볼 수 있게 구성했습니다.
+          </p>
+        </div>
+      </PageIntro>
+
+      <div className="grid gap-6 xl:grid-cols-[20rem_minmax(0,1fr)]">
+        <Card className="h-fit">
+          <CardContent className="p-5">
+            <div className="flex items-center justify-between">
+              <p className="section-kicker">Items</p>
+              {usingDemoReviews ? <Badge variant="outline">데모 데이터</Badge> : null}
+            </div>
+            <div className="mt-4 space-y-3">
+              {reviewEnabledItems.length > 0 ? (
+                reviewEnabledItems.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => setSelectedItemId(String(item.id))}
+                    className={cn(
+                      "metric-chip w-full rounded-[1.4rem] px-4 py-4 text-left transition-all",
+                      String(item.id) === activeItemId &&
+                        "border-primary/25 ring-2 ring-primary/12"
+                    )}
+                  >
+                    <p className="truncate text-sm font-semibold text-foreground">
+                      {item.title}
+                    </p>
+                    <div className="mt-2 flex items-center justify-between text-sm">
+                      <span className="text-amber-500">{renderStars(item.averageRating)}</span>
+                      <span className="text-muted-foreground">{item.reviewCount ?? 0}개</span>
+                    </div>
+                  </button>
+                ))
+              ) : (
+                <div className="rounded-[1.5rem] border border-dashed border-border px-4 py-8 text-center">
+                  <MessageSquareQuote size={20} className="mx-auto text-primary/70" />
+                  <p className="mt-3 text-sm text-muted-foreground">리뷰가 달린 상품이 없습니다.</p>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="overflow-hidden">
+          <div className="border-b border-white/70 px-6 py-5 dark:border-slate-800">
+            <p className="section-kicker">Collected reviews</p>
+            <h2 className="display-title mt-2 text-2xl text-foreground">
+              {selectedItem ? selectedItem.title : "리뷰 상세"}
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {selectedItem
+                ? `평점 ${selectedItem.averageRating ?? 0} / 리뷰 ${selectedItem.reviewCount ?? 0}개`
+                : "왼쪽에서 상품을 선택하면 리뷰를 확인할 수 있습니다."}
+            </p>
+          </div>
+
+          <CardContent className="p-6">
+            {!selectedItem ? (
+              <div className="rounded-[1.8rem] border border-dashed border-border px-6 py-10 text-center">
+                <Star size={24} className="mx-auto text-primary/70" />
+                <p className="mt-3 text-sm text-muted-foreground">상품을 선택해주세요.</p>
+              </div>
+            ) : reviewsQuery.isLoading && !usingDemoReviews ? (
+              <div className="rounded-[1.8rem] border border-dashed border-border px-6 py-10 text-center text-sm text-muted-foreground">
+                리뷰를 불러오는 중입니다.
+              </div>
+            ) : reviews.length > 0 ? (
+              <div className="space-y-4">
+                {reviews.map((review) => (
+                  <div key={review.id} className="metric-chip rounded-[1.55rem] px-5 py-5">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-foreground">
+                          {review.title || "제목 없음"}
+                        </p>
+                        <p className="mt-1 text-[0.82rem] text-muted-foreground">
+                          회원 #{review.userId} · {formatDate(review.createdAt)}
+                        </p>
+                      </div>
+                      <Badge variant="outline">{renderStars(review.rating)}</Badge>
+                    </div>
+
+                    <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                      {review.content || "리뷰 내용이 없습니다."}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-[1.8rem] border border-dashed border-border px-6 py-10 text-center">
+                <MessageSquareQuote size={24} className="mx-auto text-primary/70" />
+                <p className="mt-3 text-sm text-muted-foreground">
+                  선택한 상품의 리뷰가 없습니다.
+                </p>
+              </div>
+            )}
+
+            {reviewsQuery.isError && !usingDemoReviews ? (
+              <div className="mt-4">
+                <Button variant="outline" size="sm" onClick={() => reviewsQuery.refetch()}>
+                  다시 불러오기
+                </Button>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/domains/store/api/storeApi.js
+++ b/src/domains/store/api/storeApi.js
@@ -1,9 +1,13 @@
 import apiInstance from "@/common/api/apiInstance.js";
+import { demoCreateStore, isDemoModeEnabled } from "@/domains/management/mock/demoBackend.js";
 
 
 
 //"http://localhost:8072/api/store"
 export async function createStore(data) {
+  if (isDemoModeEnabled()) {
+    return demoCreateStore(data)
+  }
   const response = await apiInstance.post(`/store`, data,{
     headers: {
       "X-User-Id": 505, // headers 지우기

--- a/src/domains/store/page/StoreCreate.jsx
+++ b/src/domains/store/page/StoreCreate.jsx
@@ -1,190 +1,601 @@
-import { useActionState, useState } from "react"
+import { useActionState, useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import {
-  ChevronRight, Check
-} from "lucide-react"
-import { createStoreAction } from "@/domains/store/actions/createStoreAction"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Alert, AlertDescription } from "@/components/ui/alert"
-import { cn } from "@/lib/utils"
+  ArrowRight,
+  BarChart3,
+  Check,
+  ChevronRight,
+  FileText,
+  MapPin,
+  Phone,
+  ShieldCheck,
+  Store,
+} from "lucide-react";
+
+import { createStoreAction } from "@/domains/store/actions/createStoreAction";
+import { useMyStoreQuery } from "@/domains/items/hook/useItemsQuery.js";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { cn } from "@/lib/utils";
 import Step1 from "@/components/store/Step1.jsx";
 import Step2 from "@/components/store/Step2.jsx";
 import Step3 from "@/components/store/Step3.jsx";
 import Step4 from "@/components/store/Step4.jsx";
 import ReviewSummary from "@/components/store/ReviewSummary.jsx";
+import PageIntro from "@/components/layout/PageIntro.jsx";
 
-const STEPS = ["기본 정보", "주소", "연락처", "소개 & 이미지"]
-
-
+const STEPS = ["기본 정보", "주소", "연락처", "소개 & 이미지"];
+const FLOW_STEPS = [...STEPS, "최종 확인"];
+const STATUS_LABEL = {
+  ACTIVE: "운영 중",
+  INACTIVE: "비공개",
+};
 
 const INITIAL_FORM = {
-  store_name: "", status: "INACTIVE",
-  addresses: [], contacts: [],
-  description: "", thumbnail: null, gallery: [],
+  store_name: "",
+  status: "INACTIVE",
+  addresses: [],
+  contacts: [],
+  description: "",
+  thumbnail: null,
+  gallery: [],
+};
+
+function getStoreName(store) {
+  return store?.store_name ?? store?.storeName ?? store?.name ?? "내 가게";
+}
+
+function getStoreStatus(store) {
+  return store?.status ?? "INACTIVE";
+}
+
+function getAddresses(store) {
+  return Array.isArray(store?.addresses) ? store.addresses : [];
+}
+
+function getContacts(store) {
+  return Array.isArray(store?.contacts) ? store.contacts : [];
+}
+
+function getAddressText(address) {
+  if (!address) return "주소 정보 없음";
+
+  const main = address.address ?? address.roadAddress ?? address.baseAddress ?? "";
+  const detail = address.detail_address ?? address.detailAddress ?? "";
+
+  return [main, detail].filter(Boolean).join(" ");
+}
+
+function getContactText(contact) {
+  return contact?.contact_value ?? contact?.contactValue ?? "연락처 정보 없음";
 }
 
 function StepIndicator({ current }) {
   return (
-    <div className="flex items-center mb-8">
-      {STEPS.map((label, i) => (
-        <div key={i} className="flex items-center">
-          <div className="flex flex-col items-center">
-            <div className={cn(
-              "w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold transition-all",
-              i < current && "bg-primary text-primary-foreground",
-              i === current && "bg-primary text-primary-foreground ring-4 ring-accent",
-              i > current && "bg-muted text-muted-foreground"
-            )}>
-              {i < current ? <Check size={14} /> : i + 1}
+    <div className="grid gap-3 lg:grid-cols-5">
+      {FLOW_STEPS.map((label, i) => {
+        const done = i < current;
+        const active = i === current;
+
+        return (
+          <div
+            key={label}
+            className={cn(
+              "metric-chip flex items-center gap-3 rounded-[1.5rem] px-4 py-4 transition-all",
+              active &&
+                "border-primary/20 bg-[linear-gradient(135deg,rgba(255,255,255,0.95),rgba(219,234,254,0.84))] shadow-[0_18px_40px_rgba(59,130,246,0.16)] dark:border-sky-400/20 dark:bg-[linear-gradient(135deg,rgba(8,15,31,0.96),rgba(15,23,42,0.84))]",
+              done &&
+                "bg-primary text-white shadow-[0_14px_30px_rgba(29,161,242,0.18)]"
+            )}
+          >
+            <div
+              className={cn(
+                "grid h-11 w-11 shrink-0 place-items-center rounded-[1.1rem] border text-sm font-semibold transition-all",
+                done
+                  ? "border-white/14 bg-white/12 text-white"
+                  : active
+                    ? "border-primary/14 bg-primary text-primary-foreground"
+                    : "border-white/80 bg-white/70 text-muted-foreground dark:border-slate-700 dark:bg-slate-950/40"
+              )}
+            >
+              {done ? <Check size={16} /> : i + 1}
             </div>
-            <span className={cn(
-              "text-xs mt-1 font-medium whitespace-nowrap",
-              i === current ? "text-primary" : "text-muted-foreground"
-            )}>
-              {label}
-            </span>
+            <div className="min-w-0">
+              <p
+                className={cn(
+                  "text-[0.68rem] font-semibold uppercase tracking-[0.22em]",
+                  done
+                    ? "text-white/70"
+                    : active
+                      ? "text-primary/80"
+                      : "text-muted-foreground"
+                )}
+              >
+                Step {i + 1}
+              </p>
+              <p className="mt-1 truncate text-sm font-semibold">{label}</p>
+            </div>
           </div>
-          {i < STEPS.length - 1 && (
-            <div className={cn(
-              "h-px w-12 sm:w-20 mx-1 mb-4 transition-all",
-              i < current ? "bg-primary" : "bg-border"
-            )} />
-          )}
-        </div>
-      ))}
+        );
+      })}
     </div>
-  )
+  );
 }
 
+function StoreOverview({ store }) {
+  const storeName = getStoreName(store);
+  const status = getStoreStatus(store);
+  const addresses = getAddresses(store);
+  const contacts = getContacts(store);
+  const description = store?.description ?? "가게 소개가 아직 등록되지 않았습니다.";
 
+  return (
+    <div className="mx-auto max-w-6xl space-y-6">
+      <PageIntro
+        eyebrow="Store Management"
+        title="가게 관리"
+        description="가게의 기본 정보와 운영 상태를 확인하는 메인 관리 화면입니다. 첫 진입 동선은 대시보드로 옮기고, 이 페이지는 스토어 엔티티 관리에 집중하도록 정리했습니다."
+        meta={[
+          STATUS_LABEL[status] ?? status,
+          `주소 ${addresses.length}개`,
+          `연락처 ${contacts.length}개`,
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Store status
+          </p>
+          <p className="mt-3 text-lg font-semibold text-foreground">
+            {STATUS_LABEL[status] ?? status}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            가게가 이미 존재하므로 메인 진입은 판매 대시보드로 연결됩니다.
+          </p>
+        </div>
+      </PageIntro>
 
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardContent className="p-5">
+            <p className="section-kicker">Store</p>
+            <p className="mt-3 text-lg font-semibold text-foreground">{storeName}</p>
+            <Badge
+              variant={status === "ACTIVE" ? "default" : "outline"}
+              className="mt-3 w-fit"
+            >
+              {STATUS_LABEL[status] ?? status}
+            </Badge>
+          </CardContent>
+        </Card>
 
+        <Card>
+          <CardContent className="p-5">
+            <p className="section-kicker">Address</p>
+            <p className="mt-3 text-lg font-semibold text-foreground">{addresses.length}개</p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {addresses[0] ? getAddressText(addresses[0]) : "등록된 주소 없음"}
+            </p>
+          </CardContent>
+        </Card>
 
+        <Card>
+          <CardContent className="p-5">
+            <p className="section-kicker">Contact</p>
+            <p className="mt-3 text-lg font-semibold text-foreground">{contacts.length}개</p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {contacts[0] ? getContactText(contacts[0]) : "등록된 연락처 없음"}
+            </p>
+          </CardContent>
+        </Card>
 
+        <Card>
+          <CardContent className="p-5">
+            <p className="section-kicker">Next</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button asChild size="sm">
+                <Link to="/business/dashboard">
+                  대시보드 <ArrowRight size={14} />
+                </Link>
+              </Button>
+              <Button asChild size="sm" variant="outline">
+                <Link to="/business/items">상품 관리</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
 
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center gap-2">
+              <Store size={18} className="text-primary" />
+              <h2 className="display-title text-2xl font-semibold text-foreground">
+                기본 정보
+              </h2>
+            </div>
 
-export default function StoreCreatePage() {
-  const [step, setStep] = useState(0)
-  const [stepErrors, setStepErrors] = useState({})
-  const [formData, setFormData] = useState(INITIAL_FORM)
+            <div className="mt-5 grid gap-4 sm:grid-cols-2">
+              <div className="metric-chip rounded-[1.4rem] px-4 py-4">
+                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                  Store name
+                </p>
+                <p className="mt-2 text-sm font-semibold text-foreground">{storeName}</p>
+              </div>
 
-  const [state, formAction, isPending] = useActionState(createStoreAction,
-      { success: false, errors: {} })
+              <div className="metric-chip rounded-[1.4rem] px-4 py-4">
+                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                  Visibility
+                </p>
+                <p className="mt-2 text-sm font-semibold text-foreground">
+                  {STATUS_LABEL[status] ?? status}
+                </p>
+              </div>
+            </div>
 
+            <div className="mt-5 rounded-[1.5rem] border border-border/80 bg-white/60 p-4 dark:bg-slate-950/24">
+              <div className="flex items-center gap-2">
+                <FileText size={16} className="text-primary" />
+                <p className="text-sm font-semibold text-foreground">가게 소개</p>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                {description}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6">
+          <Card>
+            <CardContent className="p-6">
+              <div className="flex items-center gap-2">
+                <MapPin size={18} className="text-primary" />
+                <h2 className="display-title text-2xl font-semibold text-foreground">
+                  주소 정보
+                </h2>
+              </div>
+
+              <div className="mt-5 space-y-3">
+                {addresses.length > 0 ? (
+                  addresses.map((address, index) => (
+                    <div
+                      key={`${address?.id ?? "address"}-${index}`}
+                      className="metric-chip rounded-[1.35rem] px-4 py-4"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-semibold text-foreground">
+                          {address?.address_type ?? address?.addressType ?? `주소 ${index + 1}`}
+                        </p>
+                        {address?.is_default || address?.isDefault ? (
+                          <Badge variant="outline">기본 주소</Badge>
+                        ) : null}
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                        {getAddressText(address)}
+                      </p>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-muted-foreground">등록된 주소가 없습니다.</p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="p-6">
+              <div className="flex items-center gap-2">
+                <Phone size={18} className="text-primary" />
+                <h2 className="display-title text-2xl font-semibold text-foreground">
+                  연락처 정보
+                </h2>
+              </div>
+
+              <div className="mt-5 space-y-3">
+                {contacts.length > 0 ? (
+                  contacts.map((contact, index) => (
+                    <div
+                      key={`${contact?.id ?? "contact"}-${index}`}
+                      className="metric-chip rounded-[1.35rem] px-4 py-4"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-semibold text-foreground">
+                          {contact?.contact_type ?? contact?.contactType ?? `연락처 ${index + 1}`}
+                        </p>
+                        {contact?.is_primary || contact?.isPrimary ? (
+                          <Badge variant="outline">대표 연락처</Badge>
+                        ) : null}
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                        {getContactText(contact)}
+                      </p>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-muted-foreground">등록된 연락처가 없습니다.</p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StoreOnboardingFlow() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [step, setStep] = useState(0);
+  const [stepErrors, setStepErrors] = useState({});
+  const [formData, setFormData] = useState(INITIAL_FORM);
+
+  const [state, formAction, isPending] = useActionState(createStoreAction, {
+    success: false,
+    errors: {},
+  });
+
+  useEffect(() => {
+    if (!state.success) return;
+
+    queryClient.invalidateQueries({ queryKey: ["store", "me"] });
+    navigate("/business/dashboard", { replace: true });
+  }, [navigate, queryClient, state.success]);
 
   const handleChange = (e) => {
-    const { name, value } = e.target
-    setFormData((p) => ({ ...p, [name]: value }))
-    if (stepErrors[name]) setStepErrors((p) => ({ ...p, [name]: null }))
-  }
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    if (stepErrors[name]) {
+      setStepErrors((prev) => ({ ...prev, [name]: null }));
+    }
+  };
 
   const validateStep = () => {
-    const errs = {}
+    const errors = {};
 
     if (step === 0) {
-      if (!formData.store_name.trim()) errs.store_name = "가게명을 입력해주세요."
+      if (!formData.store_name.trim()) {
+        errors.store_name = "가게명을 입력해주세요.";
+      }
     }
 
     if (step === 1) {
       if (formData.addresses.length === 0) {
-        errs._step = "주소를 최소 1개 이상 추가해주세요."
-      } else if (formData.addresses.some((a) => !a.address.trim())) {
-        errs._step = "모든 주소를 입력해주세요."
+        errors._step = "주소를 최소 1개 이상 추가해주세요.";
+      } else if (formData.addresses.some((address) => !address.address.trim())) {
+        errors._step = "모든 주소를 입력해주세요.";
       }
     }
 
     if (step === 2) {
       if (formData.contacts.length === 0) {
-        errs._step = "연락처를 최소 1개 이상 추가해주세요."
+        errors._step = "연락처를 최소 1개 이상 추가해주세요.";
       } else {
-        formData.contacts.forEach((c, i) => {
-          if (!c.contact_value.trim()) {
-            errs[`contact_${i}`] = "연락처 값을 입력해주세요."
-          } else if (c.contact_type === "PHONE") {
-            const digits = c.contact_value.replace(/-/g, "")
+        formData.contacts.forEach((contact, index) => {
+          if (!contact.contact_value.trim()) {
+            errors[`contact_${index}`] = "연락처 값을 입력해주세요.";
+          } else if (contact.contact_type === "PHONE") {
+            const digits = contact.contact_value.replace(/-/g, "");
             if (!/^\d+$/.test(digits)) {
-              errs[`contact_${i}`] = "숫자만 입력해주세요."
+              errors[`contact_${index}`] = "숫자만 입력해주세요.";
             } else if (!digits.startsWith("010")) {
-              errs[`contact_${i}`] = "010으로 시작해야 합니다."
+              errors[`contact_${index}`] = "010으로 시작해야 합니다.";
             } else if (digits.length !== 11) {
-              errs[`contact_${i}`] = "010을 포함한 11자리를 입력해주세요."
+              errors[`contact_${index}`] = "010을 포함한 11자리를 입력해주세요.";
             }
           }
-        })
+        });
       }
     }
 
-    setStepErrors(errs)
-    return Object.keys(errs).length === 0
-  }
-
+    setStepErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
 
   if (state.success) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
-          <Check size={32} className="text-primary" />
+      <div className="mx-auto flex min-h-[60vh] max-w-xl items-center justify-center">
+        <div className="glass-panel surface-hero flex w-full flex-col items-center gap-4 rounded-[2rem] px-8 py-12 text-center">
+          <Badge variant="outline">Store ready</Badge>
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/12">
+            <Check size={32} className="text-primary" />
+          </div>
+          <h2 className="display-title text-3xl font-semibold">가게 생성 완료!</h2>
+          <p className="max-w-md text-sm leading-6 text-muted-foreground">
+            가게가 성공적으로 등록되었습니다. 메인 동선은 이제 판매 대시보드로 전환됩니다.
+          </p>
         </div>
-        <h2 className="text-xl font-bold">가게 생성 완료!</h2>
-        <p className="text-muted-foreground text-sm">가게가 성공적으로 등록되었습니다.</p>
-        <Button onClick={() => { setStep(0); setFormData(INITIAL_FORM) }}>다시 생성하기</Button>
       </div>
-    )
+    );
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold">가게 생성</h1>
-        <p className="text-muted-foreground text-sm mt-1">새로운 가게를 등록하세요.</p>
-      </div>
-      <StepIndicator current={step} />
-      <Card>
-        <CardContent className="p-6 sm:p-8 min-h-80">
-          {step === 0 && <Step1 data={formData} onChange={handleChange} errors={stepErrors} />}
-          {step === 1 && <Step2 data={formData} onChange={handleChange} />}
-          {step === 2 && <Step3 data={formData} onChange={handleChange} errors={stepErrors} />}
-          {step === 3 && <Step4 data={formData} onChange={handleChange} />}
-          {step === 4 && <ReviewSummary data={formData} />}
-        </CardContent>
-      </Card>
-      {stepErrors._step && (
-        <Alert variant="destructive" className="mt-4">
-          <AlertDescription>{stepErrors._step}</AlertDescription>
-        </Alert>
-      )}
+    <div className="mx-auto max-w-6xl space-y-6">
+      <PageIntro
+        eyebrow="Store Onboarding"
+        title="가게 등록"
+        description="가게가 아직 없기 때문에 먼저 스토어 온보딩을 진행합니다. 등록이 끝나면 메인 진입은 자동으로 대시보드 중심 구조로 전환됩니다."
+        meta={[
+          `진행 단계 ${step + 1}/${FLOW_STEPS.length}`,
+          `주소 ${formData.addresses.length}개`,
+          `연락처 ${formData.contacts.length}개`,
+        ]}
+      >
+        <div className="metric-chip rounded-[1.75rem] px-5 py-5">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            Entry rule
+          </p>
+          <p className="mt-3 text-lg font-semibold text-foreground">
+            등록 완료 후 메인 진입은 대시보드
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            이 화면은 최초 1회 온보딩 성격이고, 이후에는 가게 관리 화면으로 바뀝니다.
+          </p>
+        </div>
+      </PageIntro>
 
-      <div className="flex justify-between mt-5">
-        <Button variant="outline" onClick={() => { setStepErrors({}); setStep((s) => Math.max(s - 1, 0)) }} disabled={step === 0}>
-          이전
-        </Button>
-        {step <= STEPS.length - 1 && (
-          <Button onClick={() => { if (validateStep()) setStep((s) => s + 1) }}>
-            다음 <ChevronRight size={16} />
-          </Button>
-        )}
-        {step === STEPS.length && (
-          <form action={formAction} className="flex flex-col items-end gap-2">
-            <input type="hidden" name="store_name" value={formData.store_name} />
-            <input type="hidden" name="status" value={formData.status} />
-            <input type="hidden" name="addresses" value={JSON.stringify(formData.addresses)} />
-            <input type="hidden" name="contacts" value={JSON.stringify(formData.contacts)} />
-            <input type="hidden" name="description" value={formData.description} />
-            {state.errors && Object.keys(state.errors).length > 0 && (
-              <Alert variant="destructive">
-                <AlertDescription>
-                  {state.errors._form?.[0]
-                    ?? Object.values(state.errors).flat()[0]
-                    ?? "입력 정보를 확인해주세요."}
-                </AlertDescription>
-              </Alert>
-            )}
-            <Button type="submit" disabled={isPending}>
-              <Check size={16} /> {isPending ? "생성 중..." : "가게 생성"}
-            </Button>
-          </form>
-        )}
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_18rem]">
+        <div className="space-y-5">
+          <Card>
+            <CardContent className="p-6 sm:p-7">
+              <StepIndicator current={step} />
+              <div className="mt-6">
+                {step === 0 && <Step1 data={formData} onChange={handleChange} errors={stepErrors} />}
+                {step === 1 && <Step2 data={formData} onChange={handleChange} />}
+                {step === 2 && <Step3 data={formData} onChange={handleChange} errors={stepErrors} />}
+                {step === 3 && <Step4 data={formData} onChange={handleChange} />}
+                {step === 4 && <ReviewSummary data={formData} />}
+              </div>
+            </CardContent>
+          </Card>
+
+          {stepErrors._step && (
+            <Alert variant="destructive">
+              <AlertDescription>{stepErrors._step}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="glass-panel flex flex-col gap-3 rounded-[1.75rem] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              {step < FLOW_STEPS.length - 1
+                ? "각 단계의 핵심 정보만 채우면 다음 단계로 이동합니다."
+                : "최종 확인 후 가게를 생성합니다."}
+            </p>
+
+            <div className="flex flex-wrap items-center justify-end gap-3">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setStepErrors({});
+                  setStep((value) => Math.max(value - 1, 0));
+                }}
+                disabled={step === 0}
+              >
+                이전
+              </Button>
+              {step <= STEPS.length - 1 && (
+                <Button
+                  onClick={() => {
+                    if (validateStep()) setStep((value) => value + 1);
+                  }}
+                >
+                  다음 <ChevronRight size={16} />
+                </Button>
+              )}
+              {step === STEPS.length && (
+                <form action={formAction} className="flex flex-col items-end gap-2">
+                  <input type="hidden" name="store_name" value={formData.store_name} />
+                  <input type="hidden" name="status" value={formData.status} />
+                  <input
+                    type="hidden"
+                    name="addresses"
+                    value={JSON.stringify(formData.addresses)}
+                  />
+                  <input
+                    type="hidden"
+                    name="contacts"
+                    value={JSON.stringify(formData.contacts)}
+                  />
+                  <input type="hidden" name="description" value={formData.description} />
+                  {state.errors && Object.keys(state.errors).length > 0 && (
+                    <Alert variant="destructive">
+                      <AlertDescription>
+                        {state.errors._form?.[0] ??
+                          Object.values(state.errors).flat()[0] ??
+                          "입력 정보를 확인해주세요."}
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                  <Button type="submit" disabled={isPending}>
+                    <Check size={16} /> {isPending ? "생성 중..." : "가게 생성"}
+                  </Button>
+                </form>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <Card className="h-fit xl:sticky xl:top-[9rem]">
+          <CardContent className="p-5">
+            <p className="section-kicker">Snapshot</p>
+            <div className="mt-4 space-y-4">
+              <div className="metric-chip rounded-[1.4rem] px-4 py-4">
+                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                  Store name
+                </p>
+                <p className="mt-2 text-sm font-semibold text-foreground">
+                  {formData.store_name || "아직 입력 전"}
+                </p>
+              </div>
+
+              <div className="metric-chip rounded-[1.4rem] px-4 py-4">
+                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                  Status
+                </p>
+                <Badge
+                  variant={formData.status === "ACTIVE" ? "default" : "outline"}
+                  className="mt-2 w-fit"
+                >
+                  {formData.status}
+                </Badge>
+              </div>
+
+              <div className="metric-chip rounded-[1.4rem] px-4 py-4">
+                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                  Assets
+                </p>
+                <p className="mt-2 text-sm font-semibold text-foreground">
+                  썸네일 {formData.thumbnail ? "1장 준비" : "없음"}
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  갤러리 {formData.gallery.length}/4
+                </p>
+              </div>
+
+              <div className="metric-chip rounded-[1.4rem] px-4 py-4">
+                <div className="flex items-center gap-2">
+                  <ShieldCheck size={16} className="text-primary" />
+                  <p className="text-sm font-semibold text-foreground">
+                    등록 후 이동 경로
+                  </p>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                  가게가 생성되면 메인 동선은 `가게 관리`가 아니라 `판매 대시보드`로 바뀝니다.
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     </div>
-  )
+  );
+}
+
+export default function StoreCreatePage() {
+  const { data: myStore, isLoading } = useMyStoreQuery();
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto flex min-h-[45vh] max-w-3xl items-center justify-center">
+        <div className="glass-panel flex w-full flex-col items-center gap-3 rounded-[1.8rem] px-6 py-10 text-center">
+          <Store size={28} className="text-primary" />
+          <h2 className="display-title text-2xl font-semibold text-foreground">
+            가게 정보를 불러오는 중
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            돈모아 판매 워크스페이스를 확인한 뒤, 맞는 시작 화면으로 연결합니다.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (myStore) {
+    return <StoreOverview store={myStore} />;
+  }
+
+  return <StoreOnboardingFlow />;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,118 +1,100 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "@fontsource-variable/geist";
 
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(1.0000 0 0);
-  --foreground: oklch(0.1884 0.0128 248.5103);
-  --card: oklch(0.9784 0.0011 197.1387);
-  --card-foreground: oklch(0.1884 0.0128 248.5103);
-  --popover: oklch(1.0000 0 0);
-  --popover-foreground: oklch(0.1884 0.0128 248.5103);
-  --primary: oklch(0.6723 0.1606 244.9955);
-  --primary-foreground: oklch(1.0000 0 0);
-  --secondary: oklch(0.1884 0.0128 248.5103);
-  --secondary-foreground: oklch(1.0000 0 0);
-  --muted: oklch(0.9222 0.0013 286.3737);
-  --muted-foreground: oklch(0.1884 0.0128 248.5103);
-  --accent: oklch(0.9392 0.0166 250.8453);
-  --accent-foreground: oklch(0.6723 0.1606 244.9955);
-  --destructive: oklch(0.6188 0.2376 25.7658);
-  --destructive-foreground: oklch(1.0000 0 0);
-  --border: oklch(0.9317 0.0118 231.6594);
-  --input: oklch(0.9809 0.0025 228.7836);
-  --ring: oklch(0.6818 0.1584 243.3540);
-  --sidebar: oklch(0.9784 0.0011 197.1387);
-  --sidebar-foreground: oklch(0.1884 0.0128 248.5103);
-  --sidebar-primary: oklch(0.6723 0.1606 244.9955);
-  --sidebar-primary-foreground: oklch(1.0000 0 0);
-  --sidebar-accent: oklch(0.9392 0.0166 250.8453);
-  --sidebar-accent-foreground: oklch(0.6723 0.1606 244.9955);
-  --sidebar-border: oklch(0.9271 0.0101 238.5177);
-  --font-sans: Open Sans, sans-serif;
-  --font-mono: Menlo, monospace;
-  --radius: 1.3rem;
-  --shadow-opacity: 0;
-  --spacing: 0.25rem;
-  --chart-1: oklch(0.6723 0.1606 244.9955);
-  --chart-2: oklch(0.6907 0.1554 160.3454);
-  --chart-3: oklch(0.8214 0.1600 82.5337);
-  --chart-4: oklch(0.7064 0.1822 151.7125);
-  --chart-5: oklch(0.5919 0.2186 10.5826);
-  --sidebar-ring: oklch(0.6818 0.1584 243.3540);
+  --background: rgb(255, 255, 255);
+  --foreground: rgb(15, 20, 25);
+  --card: rgba(255, 255, 255, 0.84);
+  --card-foreground: rgb(15, 20, 25);
+  --popover: rgba(255, 255, 255, 0.95);
+  --popover-foreground: rgb(15, 20, 25);
+  --primary: rgb(30, 157, 241);
+  --primary-foreground: rgb(255, 255, 255);
+  --secondary: rgb(15, 20, 25);
+  --secondary-foreground: rgb(255, 255, 255);
+  --muted: rgba(229, 229, 230, 0.72);
+  --muted-foreground: rgb(88, 99, 110);
+  --accent: rgba(227, 236, 246, 0.84);
+  --accent-foreground: rgb(30, 157, 241);
+  --destructive: rgb(244, 33, 46);
+  --destructive-foreground: rgb(255, 255, 255);
+  --border: rgba(225, 232, 237, 0.82);
+  --input: rgba(247, 249, 250, 0.95);
+  --ring: rgba(29, 161, 242, 0.24);
+  --sidebar: rgba(247, 248, 248, 0.8);
+  --sidebar-foreground: rgb(15, 20, 25);
+  --sidebar-primary: rgb(30, 157, 241);
+  --sidebar-primary-foreground: rgb(255, 255, 255);
+  --sidebar-accent: rgba(227, 236, 246, 0.84);
+  --sidebar-accent-foreground: rgb(30, 157, 241);
+  --sidebar-border: rgba(225, 232, 237, 0.9);
+  --sidebar-ring: rgba(29, 161, 242, 0.24);
+  --chart-1: rgb(30, 157, 241);
+  --chart-2: rgb(0, 184, 122);
+  --chart-3: rgb(247, 185, 40);
+  --chart-4: rgb(23, 191, 99);
+  --chart-5: rgb(224, 36, 94);
+  --font-sans: "Space Grotesk", "IBM Plex Sans KR", sans-serif;
+  --font-display: "Space Grotesk", "IBM Plex Sans KR", sans-serif;
   --font-serif: Georgia, serif;
-  --shadow-color: rgba(29,161,242,0.15);
+  --font-mono: Menlo, monospace;
+  --radius: 1.35rem;
+  --shadow-color: rgba(29, 161, 242, 0.12);
+  --shadow-opacity: 0;
   --shadow-blur: 0px;
   --shadow-spread: 0px;
   --shadow-offset-x: 0px;
   --shadow-offset-y: 2px;
-  --letter-spacing: 0em;
-  --shadow-2xs: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-xs: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-sm: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 1px 2px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 1px 2px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-md: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 2px 4px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-lg: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 4px 6px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-xl: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 8px 10px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-2xl: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00);
+  --shadow-2xs: 0px 2px 0px 0px transparent;
+  --shadow-xs: 0px 2px 0px 0px transparent;
+  --shadow-sm: 0px 2px 0px 0px transparent;
+  --shadow: 0px 2px 0px 0px transparent;
+  --shadow-md: 0px 2px 0px 0px transparent;
+  --shadow-lg: 0px 2px 0px 0px transparent;
+  --shadow-xl: 0px 2px 0px 0px transparent;
+  --shadow-2xl: 0px 2px 0px 0px transparent;
+  --spacing: 0.25rem;
   --tracking-normal: 0em;
+  --letter-spacing: 0em;
 }
 
 .dark {
-  --background: oklch(0 0 0);
-  --foreground: oklch(0.9328 0.0025 228.7857);
-  --card: oklch(0.2097 0.0080 274.5332);
-  --card-foreground: oklch(0.8853 0 0);
-  --popover: oklch(0 0 0);
-  --popover-foreground: oklch(0.9328 0.0025 228.7857);
-  --primary: oklch(0.6692 0.1607 245.0110);
-  --primary-foreground: oklch(1.0000 0 0);
-  --secondary: oklch(0.9622 0.0035 219.5331);
-  --secondary-foreground: oklch(0.1884 0.0128 248.5103);
-  --muted: oklch(0.2090 0 0);
-  --muted-foreground: oklch(0.5637 0.0078 247.9662);
-  --accent: oklch(0.1928 0.0331 242.5459);
-  --accent-foreground: oklch(0.6692 0.1607 245.0110);
-  --destructive: oklch(0.6188 0.2376 25.7658);
-  --destructive-foreground: oklch(1.0000 0 0);
-  --border: oklch(0.2674 0.0047 248.0045);
-  --input: oklch(0.3020 0.0288 244.8244);
-  --sidebar: oklch(0.2097 0.0080 274.5332);
-  --sidebar-foreground: oklch(0.8853 0 0);
-  --sidebar-primary: oklch(0.6818 0.1584 243.3540);
-  --sidebar-primary-foreground: oklch(1.0000 0 0);
-  --sidebar-accent: oklch(0.1928 0.0331 242.5459);
-  --sidebar-accent-foreground: oklch(0.6692 0.1607 245.0110);
-  --sidebar-border: oklch(0.3795 0.0220 240.5943);
-  --radius: 1.3rem;
-  --ring: oklch(0.6818 0.1584 243.3540);
-  --chart-1: oklch(0.6723 0.1606 244.9955);
-  --chart-2: oklch(0.6907 0.1554 160.3454);
-  --chart-3: oklch(0.8214 0.1600 82.5337);
-  --chart-4: oklch(0.7064 0.1822 151.7125);
-  --chart-5: oklch(0.5919 0.2186 10.5826);
-  --sidebar-ring: oklch(0.6818 0.1584 243.3540);
-  --font-sans: Open Sans, sans-serif;
-  --font-serif: Georgia, serif;
-  --font-mono: Menlo, monospace;
-  --shadow-color: rgba(29,161,242,0.25);
-  --shadow-opacity: 0;
-  --shadow-blur: 0px;
-  --shadow-spread: 0px;
-  --shadow-offset-x: 0px;
-  --shadow-offset-y: 2px;
-  --letter-spacing: 0em;
-  --spacing: 0.25rem;
-  --shadow-2xs: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-xs: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-sm: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 1px 2px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 1px 2px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-md: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 2px 4px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-lg: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 4px 6px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-xl: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00), 0px 8px 10px -1px hsl(202.8169 89.1213% 53.1373% / 0.00);
-  --shadow-2xl: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0.00);
+  --background: rgb(0, 0, 0);
+  --foreground: rgb(231, 233, 234);
+  --card: rgba(15, 23, 42, 0.84);
+  --card-foreground: rgb(217, 217, 217);
+  --popover: rgba(0, 0, 0, 0.95);
+  --popover-foreground: rgb(231, 233, 234);
+  --primary: rgb(28, 156, 240);
+  --primary-foreground: rgb(255, 255, 255);
+  --secondary: rgb(240, 243, 244);
+  --secondary-foreground: rgb(15, 20, 25);
+  --muted: rgba(24, 24, 24, 0.78);
+  --muted-foreground: rgb(114, 118, 122);
+  --accent: rgba(6, 22, 34, 0.78);
+  --accent-foreground: rgb(28, 156, 240);
+  --destructive: rgb(244, 33, 46);
+  --destructive-foreground: rgb(255, 255, 255);
+  --border: rgba(56, 68, 77, 0.86);
+  --input: rgba(34, 48, 60, 0.88);
+  --ring: rgba(29, 161, 242, 0.3);
+  --sidebar: rgba(23, 24, 28, 0.88);
+  --sidebar-foreground: rgb(217, 217, 217);
+  --sidebar-primary: rgb(29, 161, 242);
+  --sidebar-primary-foreground: rgb(255, 255, 255);
+  --sidebar-accent: rgba(6, 22, 34, 0.84);
+  --sidebar-accent-foreground: rgb(28, 156, 240);
+  --sidebar-border: rgba(56, 68, 77, 0.86);
+  --sidebar-ring: rgba(29, 161, 242, 0.3);
+  --chart-1: rgb(30, 157, 241);
+  --chart-2: rgb(0, 184, 122);
+  --chart-3: rgb(247, 185, 40);
+  --chart-4: rgb(23, 191, 99);
+  --chart-5: rgb(224, 36, 94);
+  --shadow-color: rgba(29, 161, 242, 0.18);
 }
 
 @theme inline {
@@ -120,6 +102,8 @@
   --color-foreground: var(--foreground);
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--secondary);
@@ -140,8 +124,8 @@
   --color-sidebar-accent: var(--sidebar-accent);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
-  --font-sans: Open Sans, sans-serif;
-  --font-mono: Menlo, monospace;
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -152,13 +136,11 @@
   --color-chart-3: var(--chart-3);
   --color-chart-2: var(--chart-2);
   --color-chart-1: var(--chart-1);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
-  --font-serif: Georgia, serif;
-  --radius: 1.3rem;
+  --font-serif: var(--font-serif);
+  --radius: var(--radius);
   --tracking-tighter: calc(var(--tracking-normal) - 0.05em);
   --tracking-tight: calc(var(--tracking-normal) - 0.025em);
   --tracking-wide: calc(var(--tracking-normal) + 0.025em);
@@ -187,12 +169,198 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html,
+  body,
+  #root {
+    min-height: 100%;
+  }
   body {
     @apply bg-background text-foreground;
+    margin: 0;
     font-family: var(--font-sans);
     letter-spacing: var(--tracking-normal);
+    background:
+      linear-gradient(180deg, #eef5ff 0%, #f8fafc 30%, #ffffff 100%);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    overflow-x: clip;
   }
   html {
     @apply font-sans;
+  }
+  ::selection {
+    background: rgba(56, 189, 248, 0.25);
+    color: var(--foreground);
+  }
+  :where(h1, h2, h3, h4, .display-title) {
+    font-family: var(--font-display);
+    letter-spacing: -0.045em;
+  }
+}
+
+@layer components {
+  .business-shell {
+    position: relative;
+    background:
+      radial-gradient(circle at 8% 10%, rgba(56, 189, 248, 0.12), transparent 35%),
+      radial-gradient(circle at 92% 18%, rgba(14, 165, 233, 0.1), transparent 34%),
+      linear-gradient(180deg, #eef5ff 0%, #f8fafc 30%, #ffffff 100%);
+    overflow-x: clip;
+  }
+
+  .business-shell::before,
+  .auth-stage::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+    background-size: 72px 72px;
+    mask-image: linear-gradient(180deg, rgba(255, 255, 255, 0.78), transparent 92%);
+    pointer-events: none;
+  }
+
+  .auth-stage {
+    position: relative;
+    background:
+      radial-gradient(circle at 8% 10%, rgba(56, 189, 248, 0.12), transparent 35%),
+      radial-gradient(circle at 92% 18%, rgba(14, 165, 233, 0.1), transparent 34%),
+      linear-gradient(180deg, #eef5ff 0%, #f8fafc 30%, #ffffff 100%);
+    overflow: hidden;
+  }
+
+  .glass-panel {
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(244, 251, 255, 0.82));
+    border: 1px solid rgba(255, 255, 255, 0.74);
+    box-shadow:
+      0 18px 56px rgba(15, 23, 42, 0.08),
+      inset 0 1px 0 rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(22px);
+  }
+
+  .surface-hero {
+    background:
+      linear-gradient(140deg, rgba(255, 255, 255, 0.92) 0%, rgba(244, 251, 255, 0.82) 42%, rgba(250, 253, 255, 0.9) 100%);
+  }
+
+  .glass-field {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(247, 249, 250, 0.86));
+    border: 1px solid rgba(225, 232, 237, 0.88);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.76),
+      0 10px 28px rgba(148, 163, 184, 0.1);
+    backdrop-filter: blur(18px);
+  }
+
+  .metric-chip {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(248, 250, 252, 0.72));
+    border: 1px solid rgba(255, 255, 255, 0.76);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.76),
+      0 10px 28px rgba(148, 163, 184, 0.12);
+    backdrop-filter: blur(18px);
+  }
+
+  .section-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: rgb(30, 157, 241);
+  }
+
+  .section-kicker::before {
+    content: "";
+    width: 2.5rem;
+    height: 1px;
+    background: linear-gradient(90deg, rgba(30, 157, 241, 0.72), rgba(30, 157, 241, 0));
+  }
+
+  .reveal-up {
+    animation: reveal-up 0.55s cubic-bezier(0.23, 1, 0.32, 1) both;
+  }
+
+  @keyframes reveal-up {
+    from {
+      opacity: 0;
+      transform: translateY(14px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+}
+
+.dark body {
+  background:
+    linear-gradient(180deg, #050a13 0%, #0a1220 40%, #0f172a 100%);
+}
+
+.dark .business-shell {
+  background:
+    radial-gradient(circle at 8% 10%, rgba(34, 211, 238, 0.14), transparent 38%),
+    radial-gradient(circle at 92% 18%, rgba(96, 165, 250, 0.1), transparent 34%),
+    linear-gradient(180deg, #050a13 0%, #0a1220 40%, #0f172a 100%);
+}
+
+.dark .auth-stage {
+  background:
+    radial-gradient(circle at 8% 10%, rgba(34, 211, 238, 0.14), transparent 38%),
+    radial-gradient(circle at 92% 18%, rgba(96, 165, 250, 0.1), transparent 34%),
+    linear-gradient(180deg, #050a13 0%, #0a1220 40%, #0f172a 100%);
+}
+
+.dark .business-shell::before,
+.dark .auth-stage::before {
+  background-image:
+    linear-gradient(rgba(71, 85, 105, 0.18) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(71, 85, 105, 0.18) 1px, transparent 1px);
+}
+
+.dark .glass-panel {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0.8));
+  border-color: rgba(51, 65, 85, 0.92);
+  box-shadow:
+    0 24px 80px rgba(2, 6, 23, 0.42),
+    inset 0 1px 0 rgba(148, 163, 184, 0.12);
+}
+
+.dark .surface-hero {
+  background:
+    linear-gradient(140deg, rgba(15, 23, 42, 0.88) 0%, rgba(15, 23, 42, 0.8) 42%, rgba(30, 41, 59, 0.88) 100%);
+}
+
+.dark .glass-field {
+  background: linear-gradient(180deg, rgba(8, 15, 31, 0.92), rgba(15, 23, 42, 0.76));
+  border-color: rgba(51, 65, 85, 0.92);
+  box-shadow:
+    inset 0 1px 0 rgba(148, 163, 184, 0.08),
+    0 12px 36px rgba(2, 6, 23, 0.28);
+}
+
+.dark .metric-chip {
+  background: linear-gradient(180deg, rgba(8, 15, 31, 0.92), rgba(15, 23, 42, 0.74));
+  border-color: rgba(51, 65, 85, 0.82);
+  box-shadow:
+    inset 0 1px 0 rgba(148, 163, 184, 0.08),
+    0 18px 38px rgba(2, 6, 23, 0.26);
+}
+
+.dark .section-kicker {
+  color: rgb(96, 165, 250);
+}
+
+.dark .section-kicker::before {
+  background: linear-gradient(90deg, rgba(96, 165, 250, 0.72), rgba(96, 165, 250, 0));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-up {
+    animation: none;
   }
 }

--- a/src/routes/route.jsx
+++ b/src/routes/route.jsx
@@ -8,19 +8,49 @@ import AnalyticsPage from "@/domains/analytics/page/Analytics.jsx";
 import GatewayPage from "@/domains/gateway/page/Gateway.jsx";
 import LoginPage from "@/domains/auth/page/LoginPage.jsx";
 import RegisterPage from "@/domains/auth/page/RegisterPage.jsx";
+import { useMyStoreQuery } from "@/domains/items/hook/useItemsQuery.js";
+import ReviewsPage from "@/domains/reviews/page/Reviews.jsx";
+import ChatInboxPage from "@/domains/chat/page/ChatInbox.jsx";
+
+function BusinessEntryRedirect() {
+  const { data: myStore, isLoading } = useMyStoreQuery();
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto flex min-h-[40vh] max-w-3xl items-center justify-center">
+        <div className="glass-panel rounded-[1.75rem] px-6 py-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            돈모아 워크스페이스를 확인하는 중입니다.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <Navigate
+      to={myStore ? "/business/dashboard" : "/business/store"}
+      replace
+    />
+  );
+}
 
 function BusinessRoutes() {
   return (
     <BusinessLayout>
       <Routes>
-        <Route path="/" element={<Navigate to="/business/store" replace />} />
+        <Route path="/" element={<BusinessEntryRedirect />} />
+        <Route path="/business" element={<BusinessEntryRedirect />} />
         <Route path="/auth/login" element={<LoginPage/>}></Route>
         <Route path="/auth/register" element={<RegisterPage/>}></Route>
+        <Route path="/business/dashboard" element={<AnalyticsPage />} />
         <Route path="/business/store" element={<StoreCreatePage />} />
         <Route path="/business/items" element={<ItemsPage />} />
         <Route path="/business/funding" element={<FundingPage />} />
         <Route path="/business/hotdeal" element={<HotDealPage />} />
-        <Route path="/business/analytics" element={<AnalyticsPage />} />
+        <Route path="/business/reviews" element={<ReviewsPage />} />
+        <Route path="/business/messages" element={<ChatInboxPage />} />
+        <Route path="/business/analytics" element={<Navigate to="/business/dashboard" replace />} />
         <Route path="/business/gateway" element={<GatewayPage />} />
       </Routes>
     </BusinessLayout>

--- a/src/routes/route.jsx
+++ b/src/routes/route.jsx
@@ -2,8 +2,11 @@ import { Routes, Route, Navigate } from "react-router";
 import BusinessLayout from "@/components/layout/BusinessLayout.jsx";
 import StoreCreatePage from "@/domains/store/page/StoreCreate.jsx";
 import ItemsPage from "@/domains/items/page/Items.jsx";
+import ItemDetailPage from "@/domains/items/page/ItemDetail.jsx";
 import FundingPage from "@/domains/funding/page/Funding.jsx";
+import FundingDetailPage from "@/domains/funding/page/FundingDetail.jsx";
 import HotDealPage from "@/domains/hotdeal/page/HotDeal.jsx";
+import HotDealDetailPage from "@/domains/hotdeal/page/HotDealDetail.jsx";
 import AnalyticsPage from "@/domains/analytics/page/Analytics.jsx";
 import GatewayPage from "@/domains/gateway/page/Gateway.jsx";
 import LoginPage from "@/domains/auth/page/LoginPage.jsx";
@@ -46,8 +49,11 @@ function BusinessRoutes() {
         <Route path="/business/dashboard" element={<AnalyticsPage />} />
         <Route path="/business/store" element={<StoreCreatePage />} />
         <Route path="/business/items" element={<ItemsPage />} />
+        <Route path="/business/items/:itemId" element={<ItemDetailPage />} />
         <Route path="/business/funding" element={<FundingPage />} />
+        <Route path="/business/funding/:campaignId" element={<FundingDetailPage />} />
         <Route path="/business/hotdeal" element={<HotDealPage />} />
+        <Route path="/business/hotdeal/:hotDealId" element={<HotDealDetailPage />} />
         <Route path="/business/reviews" element={<ReviewsPage />} />
         <Route path="/business/messages" element={<ChatInboxPage />} />
         <Route path="/business/analytics" element={<Navigate to="/business/dashboard" replace />} />


### PR DESCRIPTION
## Summary
- redesign the business console around dashboard-first and management-first flows
- add demo-backed store, item, funding, hot deal, review, and chat flows for pre-backend walkthroughs
- align item/funding/hot deal binding layers with mapper-based API/query patterns from the reference frontend
- add item/funding detail-edit flows and hot-deal detail view

## Testing
- `npm run build` ✅
- `npm run lint` ❌ existing issue in `src/domains/auth/actions/loginAction.js` (`no-unreachable`, unused `error`)

## Notes
- chat inbox uses the generic chat room APIs as a seller inquiry inbox
- review management aggregates per-item reviews because there is no seller-scoped review inbox API yet
- hot deal detail is read-oriented because a seller-side hot deal update/delete API was not confirmed in backend contracts